### PR TITLE
Fixes issue 526: where socket.gethostbyname('$%?*') passes and messes-up test_mputil.py

### DIFF
--- a/openmdao.util/src/openmdao/util/test/test_dep.py
+++ b/openmdao.util/src/openmdao/util/test/test_dep.py
@@ -35,6 +35,7 @@ class DepTestCase(unittest.TestCase):
         comps.extend(psta.find_inheritors('enthought.traits.api.Array'))
         comps = [x.rsplit('.',1)[1] for x in comps]
         comps.remove('Driver')
+        comps.remove('DriverUsesDerivatives')
         comps.remove('CaseIterDriverBase')
         comps.remove('PassthroughTrait')
         


### PR DESCRIPTION
Just modifies test to check if the socket call passes, and if so, increments the expected number of hosts.
