### PR TITLE
Some further cleanup of the derivatives API

### DIFF
--- a/docs/simple/derivatives.rst
+++ b/docs/simple/derivatives.rst
@@ -97,11 +97,11 @@ We need to add an ``__init__`` method that defines derivatives between the input
         
         super(Paraboloid_Derivative, self).__init__()
 
-        self.derivatives.declare_first_derivative(self, 'f_xy', 'x')
-        self.derivatives.declare_first_derivative(self, 'f_xy', 'y')
-        self.derivatives.declare_second_derivative(self, 'f_xy', 'x', 'x')
-        self.derivatives.declare_second_derivative(self, 'f_xy', 'x', 'y')
-        self.derivatives.declare_second_derivative(self, 'f_xy', 'y', 'y')
+        self.derivatives.declare_first_derivative('f_xy', 'x')
+        self.derivatives.declare_first_derivative('f_xy', 'y')
+        self.derivatives.declare_second_derivative('f_xy', 'x', 'x')
+        self.derivatives.declare_second_derivative('f_xy', 'x', 'y')
+        self.derivatives.declare_second_derivative('f_xy', 'y', 'y')
 
 The ``super`` command executes the parent's ``__init__`` function. **This is
 required for the component to behave properly in OpenMDAO, so don't forget to

--- a/examples/openmdao.examples.mdao/openmdao/examples/mdao/disciplines.py
+++ b/examples/openmdao.examples.mdao/openmdao/examples/mdao/disciplines.py
@@ -8,7 +8,7 @@ From Sellar's analytic problem.
     January 1996.
 """
 
-from openmdao.main.api import Component
+from openmdao.main.api import Component, ComponentWithDerivatives
 from openmdao.lib.datatypes.api import Float
 
 
@@ -64,3 +64,103 @@ class SellarDiscipline2(Component):
         self.y2 = y1**(.5) + z1 + z2
 
 
+
+class SellarDiscipline1withDerivatives(ComponentWithDerivatives):
+    """Component containing Discipline 1"""
+    
+    # pylint: disable-msg=E1101
+    z1 = Float(0.0, iotype='in', desc='Global Design Variable')
+    z2 = Float(0.0, iotype='in', desc='Global Design Variable')
+    x1 = Float(0.0, iotype='in', desc='Local Design Variable')
+    y2 = Float(0.0, iotype='in', desc='Disciplinary Coupling')
+
+    y1 = Float(iotype='out', desc='Output of this Discipline')        
+
+
+    def __init__(self):
+        """ declare what derivatives that we can provide"""
+        
+        super(SellarDiscipline1withDerivatives, self).__init__()
+
+        self.derivatives.declare_first_derivative('y1', 'z1')
+        self.derivatives.declare_first_derivative('y1', 'z2')
+        self.derivatives.declare_first_derivative('y1', 'x1')
+        self.derivatives.declare_first_derivative('y1', 'y2')
+
+
+    def execute(self):
+        """Evaluates the equation  
+        y1 = z1**2 + z2 + x1 - 0.2*y2"""
+        
+        z1 = self.z1
+        z2 = self.z2
+        x1 = self.x1
+        y2 = self.y2
+        
+        self.y1 = z1**2 + z2 + x1 - 0.2*y2
+        #print "(%f, %f, %f)" % (z1, z2, x1)
+
+
+    def calculate_first_derivatives(self):
+        """Analytical first derivatives"""
+        
+        dy1_dz1 = 2.0*self.z1
+        dy1_dz2 = 1.0
+        dy1_dx1 = 1.0
+        dy1_dy2 = -0.2
+    
+        self.derivatives.set_first_derivative('y1', 'z1', dy1_dz1)
+        self.derivatives.set_first_derivative('y1', 'z2', dy1_dz2)
+        self.derivatives.set_first_derivative('y1', 'x1', dy1_dx1)
+        self.derivatives.set_first_derivative('y1', 'y2', dy1_dy2)
+        
+
+
+class SellarDiscipline2withDerivatives(ComponentWithDerivatives):
+    """Component containing Discipline 2"""
+    
+    # pylint: disable-msg=E1101
+    z1 = Float(0.0, iotype='in', desc='Global Design Variable')
+    z2 = Float(0.0, iotype='in', desc='Global Design Variable')
+    y1 = Float(0.0, iotype='in', desc='Disciplinary Coupling')
+
+    y2 = Float(iotype='out', desc='Output of this Discipline')        
+
+    def __init__(self):
+        """ declare what derivatives that we can provide"""
+        
+        super(SellarDiscipline2withDerivatives, self).__init__()
+
+        self.derivatives.declare_first_derivative('y2', 'z1')
+        self.derivatives.declare_first_derivative('y2', 'z2')
+        self.derivatives.declare_first_derivative('y2', 'y1')
+
+    def execute(self):
+        """Evaluates the equation  
+        y1 = y1**(.5) + z1 + z2"""
+        
+        z1 = self.z1
+        z2 = self.z2
+        
+        # Note: this may cause some issues. However, y1 is constrained to be
+        # above 3.16, so lets just let it converge, and the optimizer will 
+        # throw it out
+        y1 = abs(self.y1)
+        
+        self.y2 = y1**(.5) + z1 + z2
+
+        
+    def calculate_first_derivatives(self):
+        """Analytical first derivatives"""
+        
+        y1 = abs(self.y1)
+        
+        dy2_dz1 = 1.0
+        dy2_dz2 = 1.0
+        dy2_dy1 = .5*y1**(-.5)
+    
+        self.derivatives.set_first_derivative('y2', 'z1', dy2_dz1)
+        self.derivatives.set_first_derivative('y2', 'z2', dy2_dz2)
+        self.derivatives.set_first_derivative('y2', 'y1', dy2_dy1)
+
+        

--- a/examples/openmdao.examples.simple/openmdao/examples/simple/paraboloid_derivative.py
+++ b/examples/openmdao.examples.simple/openmdao/examples/simple/paraboloid_derivative.py
@@ -3,10 +3,10 @@
 """
 
 # pylint: disable-msg=E0611,F0401
-from openmdao.main.api import Component
+from openmdao.main.api import ComponentWithDerivatives
 from openmdao.lib.datatypes.api import Float
 
-class ParaboloidDerivative(Component):
+class ParaboloidDerivative(ComponentWithDerivatives):
     """ Evaluates the equation f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3 """
     
     # set up interface to the framework  
@@ -22,11 +22,11 @@ class ParaboloidDerivative(Component):
         
         super(ParaboloidDerivative, self).__init__()
 
-        self.derivatives.declare_first_derivative(self, 'f_xy', 'x')
-        self.derivatives.declare_first_derivative(self, 'f_xy', 'y')
-        self.derivatives.declare_second_derivative(self, 'f_xy', 'x', 'x')
-        self.derivatives.declare_second_derivative(self, 'f_xy', 'x', 'y')
-        self.derivatives.declare_second_derivative(self, 'f_xy', 'y', 'y')
+        self.derivatives.declare_first_derivative('f_xy', 'x')
+        self.derivatives.declare_first_derivative('f_xy', 'y')
+        self.derivatives.declare_second_derivative('f_xy', 'x', 'x')
+        self.derivatives.declare_second_derivative('f_xy', 'x', 'y')
+        self.derivatives.declare_second_derivative('f_xy', 'y', 'y')
 
         
     def execute(self):

--- a/openmdao.lib/src/openmdao/lib/drivers/test/test_opt_newsumtinterruptible.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/test/test_opt_newsumtinterruptible.py
@@ -663,20 +663,20 @@ class OptRosenSuzukiComponent_Deriv(ComponentWithDerivatives):
         self.opt_objective = 6.
         self.opt_design_vars = [0., 1., 2., -1.]
 
-        self.derivatives.declare_first_derivative(self, 'result', 'x1')
-        self.derivatives.declare_first_derivative(self, 'result', 'x2')
-        self.derivatives.declare_first_derivative(self, 'result', 'x3')
-        self.derivatives.declare_first_derivative(self, 'result', 'x4')
-        self.derivatives.declare_second_derivative(self, 'result', 'x1', 'x1')
-        self.derivatives.declare_second_derivative(self, 'result', 'x1', 'x2')
-        self.derivatives.declare_second_derivative(self, 'result', 'x1', 'x3')
-        self.derivatives.declare_second_derivative(self, 'result', 'x1', 'x4')
-        self.derivatives.declare_second_derivative(self, 'result', 'x2', 'x2')
-        self.derivatives.declare_second_derivative(self, 'result', 'x2', 'x3')
-        self.derivatives.declare_second_derivative(self, 'result', 'x2', 'x4')
-        self.derivatives.declare_second_derivative(self, 'result', 'x3', 'x3')
-        self.derivatives.declare_second_derivative(self, 'result', 'x3', 'x4')
-        self.derivatives.declare_second_derivative(self, 'result', 'x4', 'x4')
+        self.derivatives.declare_first_derivative('result', 'x1')
+        self.derivatives.declare_first_derivative('result', 'x2')
+        self.derivatives.declare_first_derivative('result', 'x3')
+        self.derivatives.declare_first_derivative('result', 'x4')
+        self.derivatives.declare_second_derivative('result', 'x1', 'x1')
+        self.derivatives.declare_second_derivative('result', 'x1', 'x2')
+        self.derivatives.declare_second_derivative('result', 'x1', 'x3')
+        self.derivatives.declare_second_derivative('result', 'x1', 'x4')
+        self.derivatives.declare_second_derivative('result', 'x2', 'x2')
+        self.derivatives.declare_second_derivative('result', 'x2', 'x3')
+        self.derivatives.declare_second_derivative('result', 'x2', 'x4')
+        self.derivatives.declare_second_derivative('result', 'x3', 'x3')
+        self.derivatives.declare_second_derivative('result', 'x3', 'x4')
+        self.derivatives.declare_second_derivative('result', 'x4', 'x4')
 
     def execute(self):
         """calculate the new objective value"""

--- a/openmdao.main/src/openmdao/main/component_with_derivatives.py
+++ b/openmdao.main/src/openmdao/main/component_with_derivatives.py
@@ -11,7 +11,7 @@ class ComponentWithDerivatives (Component):
     def __init__(self, *args, **kwargs):
         """ Only one thing to do: create Derivatives object."""
         
-        self.derivatives = Derivatives()
+        self.derivatives = Derivatives(self)
         super(ComponentWithDerivatives, self).__init__(*args, **kwargs)
         
         
@@ -30,7 +30,7 @@ class ComponentWithDerivatives (Component):
         
         for name in self.derivatives.out_names:
             setattr(self, name,
-                     self.derivatives.calculate_output(self, name, ffd_order))
+                     self.derivatives.calculate_output(name, ffd_order))
 
             
     def calc_derivatives(self, first=False, second=False):
@@ -71,14 +71,26 @@ class ComponentWithDerivatives (Component):
         
         local_inputs = []
         for item in driver_inputs:
-            paths = item.split('.',1)
-            if paths[0] == self.name:
-                local_inputs.append(paths[1])
+            if isinstance(item, tuple):
+                for linked_item in item:
+                    paths = linked_item.split('.',1)
+                    if paths[0] == self.name:
+                        local_inputs.append(paths[1])
+            else:
+                paths = item.split('.',1)
+                if paths[0] == self.name:
+                    local_inputs.append(paths[1])
         
         local_outputs = []
         for item in driver_outputs:
-            paths = item.split('.',1)
-            if paths[0] == self.name:
-                local_outputs.append(paths[1])
+            if isinstance(item, tuple):
+                for linked_item in item:
+                    paths = linked_item.split('.',1)
+                    if paths[0] == self.name:
+                        local_outputs.append(paths[1])
+            else:
+                paths = item.split('.',1)
+                if paths[0] == self.name:
+                    local_outputs.append(paths[1])
         
-        self.derivatives.validate(self, order, local_inputs, local_outputs)
+        self.derivatives.validate(order, local_inputs, local_outputs)

--- a/openmdao.main/src/openmdao/main/test/test_derivatives.py
+++ b/openmdao.main/src/openmdao/main/test/test_derivatives.py
@@ -25,11 +25,11 @@ class Paraboloid_Derivative(ComponentWithDerivatives):
         
         super(Paraboloid_Derivative, self).__init__()
 
-        self.derivatives.declare_second_derivative(self, 'f_xy', 'x', 'y')
-        self.derivatives.declare_second_derivative(self, 'f_xy', 'x', 'x')
-        self.derivatives.declare_second_derivative(self, 'f_xy', 'y', 'y')
-        self.derivatives.declare_first_derivative(self, 'f_xy', 'x')
-        self.derivatives.declare_first_derivative(self, 'f_xy', 'y')
+        self.derivatives.declare_second_derivative('f_xy', 'x', 'y')
+        self.derivatives.declare_second_derivative('f_xy', 'x', 'x')
+        self.derivatives.declare_second_derivative('f_xy', 'y', 'y')
+        self.derivatives.declare_first_derivative('f_xy', 'x')
+        self.derivatives.declare_first_derivative('f_xy', 'y')
         
         self.ran_real = False
 
@@ -146,16 +146,16 @@ class A_D(A):
         
         super(A_D, self).__init__()
 
-        self.derivatives.declare_first_derivative(self, 'y1', 'x1')
-        self.derivatives.declare_first_derivative(self, 'y1', 'x2')
-        self.derivatives.declare_first_derivative(self, 'y2', 'x1')
-        self.derivatives.declare_first_derivative(self, 'y2', 'x2')
-        self.derivatives.declare_second_derivative(self, 'y1', 'x1', 'x1')
-        self.derivatives.declare_second_derivative(self, 'y1', 'x1', 'x2')
-        self.derivatives.declare_second_derivative(self, 'y1', 'x2', 'x2')
-        self.derivatives.declare_second_derivative(self, 'y2', 'x1', 'x1')
-        self.derivatives.declare_second_derivative(self, 'y2', 'x1', 'x2')
-        self.derivatives.declare_second_derivative(self, 'y2', 'x2', 'x2')
+        self.derivatives.declare_first_derivative('y1', 'x1')
+        self.derivatives.declare_first_derivative('y1', 'x2')
+        self.derivatives.declare_first_derivative('y2', 'x1')
+        self.derivatives.declare_first_derivative('y2', 'x2')
+        self.derivatives.declare_second_derivative('y1', 'x1', 'x1')
+        self.derivatives.declare_second_derivative('y1', 'x1', 'x2')
+        self.derivatives.declare_second_derivative('y1', 'x2', 'x2')
+        self.derivatives.declare_second_derivative('y2', 'x1', 'x1')
+        self.derivatives.declare_second_derivative('y2', 'x1', 'x2')
+        self.derivatives.declare_second_derivative('y2', 'x2', 'x2')
         
         self.ran_real = False
         
@@ -292,7 +292,7 @@ class DerivativesTestCase(unittest.TestCase):
     def test_bad_variable_declaration(self):
         
         try:
-            self.comp.derivatives.declare_first_derivative(self.comp, 'x', 'y')
+            self.comp.derivatives.declare_first_derivative('x', 'y')
         except RuntimeError, err:
             msg = 'Variable x ' + \
                   'should be an output. '+ \
@@ -303,7 +303,7 @@ class DerivativesTestCase(unittest.TestCase):
             self.fail('RuntimeError expected')
             
         try:
-            self.comp.derivatives.declare_first_derivative(self.comp, 'f_xy', 'f_xy')
+            self.comp.derivatives.declare_first_derivative('f_xy', 'f_xy')
         except RuntimeError, err:
             msg = 'Variable f_xy ' + \
                   'should be an input. '+ \
@@ -314,7 +314,7 @@ class DerivativesTestCase(unittest.TestCase):
             self.fail('RuntimeError expected')
             
         try:
-            self.comp.derivatives.declare_second_derivative(self.comp, 'x', 'y', 'x')
+            self.comp.derivatives.declare_second_derivative('x', 'y', 'x')
         except RuntimeError, err:
             msg = 'Variable x ' + \
                   'should be an output. '+ \
@@ -327,7 +327,7 @@ class DerivativesTestCase(unittest.TestCase):
         self.comp.add('zint', Int(7777, iotype='in'))
         
         try:
-            self.comp.derivatives.declare_first_derivative(self.comp, 'f_xy', 'zint')
+            self.comp.derivatives.declare_first_derivative('f_xy', 'zint')
         except RuntimeError, err:
             msg = 'At present, derivatives can only be declared for float-' + \
                   'valued variables. Variable zint ' + \
@@ -393,7 +393,7 @@ class DerivativesTestCase(unittest.TestCase):
         
         self.comp.calc_derivatives(first=True, second=False)
         try:
-            self.comp.derivatives.calculate_output(self.comp, 'f_xy', 3)
+            self.comp.derivatives.calculate_output('f_xy', 3)
         except NotImplementedError, err:
             msg = 'Fake Finite Difference does not currently support an ' + \
                   'order of 3.'
@@ -404,7 +404,7 @@ class DerivativesTestCase(unittest.TestCase):
     def test_validate_simple(self):
 
         # Just making sure it works.
-        self.comp.derivatives.validate(self.comp, 1, [], [])
+        self.comp.derivatives.validate(1, [], [])
         
     def test_in_assembly(self):
         


### PR DESCRIPTION
No longer need the superfluous "self" argument when declaring a derivative. Also some changes in check_derivatives to handle linked design variables.

Made a few small adjustments in some of the example python files
