### PR TITLE
Closes 570 -- Updates to address problem on Rula's machine.

### DIFF
--- a/openmdao.lib/src/openmdao/lib/drivers/caseiterdriver.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/caseiterdriver.py
@@ -302,7 +302,7 @@ class CaseIterDriverBase(Driver):
                         except KeyError:
                             self._logger.error('    %r: no startup reply', name)
                         else:
-                            self._logger.error('    %r: %s %s %s', name,
+                            self._logger.error('    %r: %r %s %s', name,
                                                self._servers[name],
                                                self._server_states[name],
                                                self._server_info[name])

--- a/openmdao.lib/src/openmdao/lib/drivers/test/test_caseiterdriver.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/test/test_caseiterdriver.py
@@ -208,7 +208,7 @@ class TestCase(unittest.TestCase):
         else:
             assert_raises(self, 'self.model.run()', globals(), locals(),
                           RuntimeError,
-                          "driver: Run aborted: RuntimeError('driven: Forced error',)")
+                          "driver: Run aborted: driven: Forced error")
 
     def verify_results(self, forced_errors=False):
         """ Verify recorded results match expectations. """

--- a/openmdao.main/src/openmdao/main/mp_support.py
+++ b/openmdao.main/src/openmdao/main/mp_support.py
@@ -1073,6 +1073,13 @@ class OpenMDAO_Proxy(BaseProxy):
         key, and the entry is removed before being passed to :class:`BaseProxy`.
 
     This version sends credentials and provides dynamic result proxy generation.
+
+    .. note::
+
+        :meth:`BaseProxy.__str__` (used by :meth:`str` and the ``%s`` format)
+        will return :meth:`__repr__` of the remote object.  To avoid the
+        network round-trip delay, use :meth:`repr` or the ``%r`` format.
+
     """
 
     def __init__(self, *args, **kwds):
@@ -1107,8 +1114,8 @@ class OpenMDAO_Proxy(BaseProxy):
             try:
                 self._connect()
             except Exception as exc:
-                msg = "Can't connect to server at %r: %r" \
-                      % (self._token.address, exc)
+                msg = "Can't connect to server at %r for %r: %r" \
+                      % (self._token.address, methodname, exc)
                 logging.error(msg)
                 raise RuntimeError(msg)
             conn = self._tls.connection
@@ -1136,7 +1143,8 @@ class OpenMDAO_Proxy(BaseProxy):
             conn.send(encrypt((self._id, methodname, new_args, kwds,
                                get_credentials().encode()), session_key))
         except IOError as exc:
-            msg = "Can't send to server at %r: %r" % (self._token.address, exc)
+            msg = "Can't send to server at %r for %r: %r" \
+                  % (self._token.address, methodname, exc)
             logging.error(msg)
             raise RuntimeError(msg)
 

--- a/openmdao.main/src/openmdao/main/objserverfactory.py
+++ b/openmdao.main/src/openmdao/main/objserverfactory.py
@@ -260,7 +260,7 @@ class ObjServerFactory(Factory):
         else:
             obj = server
 
-        self._logger.debug('create returning %s at %r', obj, obj._token.address)
+        self._logger.debug('create returning %r at %r', obj, obj._token.address)
         return obj
 
 

--- a/openmdao.util/src/openmdao/util/test/test_dep.py
+++ b/openmdao.util/src/openmdao/util/test/test_dep.py
@@ -36,6 +36,7 @@ class DepTestCase(unittest.TestCase):
         comps = [x.rsplit('.',1)[1] for x in comps]
         comps.remove('Driver')
         comps.remove('DriverUsesDerivatives')
+        comps.remove('DistributionCaseDriver')
         comps.remove('CaseIterDriverBase')
         comps.remove('PassthroughTrait')
         comps.remove('PassthroughProperty')

--- a/openmdao.util/src/openmdao/util/testutil.py
+++ b/openmdao.util/src/openmdao/util/testutil.py
@@ -53,7 +53,7 @@ def assert_raises(test_case, code, globals, locals, exception, msg,
 def assert_rel_error(test_case, actual, desired, tolerance):
     """
     Determine that the relative error between `actual` and `desired`
-    is within `tolerance`.
+    is within `tolerance`. If `desired` is zero then use absolute error.
 
     test_case: :class:`unittest.TestCase`
         TestCase instance used for assertions.
@@ -70,8 +70,10 @@ def assert_rel_error(test_case, actual, desired, tolerance):
     if isnan(actual) and not isnan(desired):
         test_case.fail('actual nan, desired %s, error nan, tolerance %s'
                        % (desired, tolerance))
-    
-    error = (actual - desired) / desired
+    if desired != 0:
+        error = (actual - desired) / desired
+    else:
+        error = actual - desired
     if abs(error) > tolerance:
         test_case.fail('actual %s, desired %s, error %s, tolerance %s'
                        % (actual, desired, error, tolerance))


### PR DESCRIPTION
The closest thing to a 'fix' here is to avoid the network round-trip implied by BaseProxy.**str**() in objserverfactory.py logging.  It does avoid the errors logged in Herb's message.  Never reproduced the defunct process problem, nor did I find any reason that there should be a problem through a shutdown code review. I'm guessing the send/connect errors logged are multiprocessing proxies attempting to be cleaned up, but it's happening after the servers have been shut down. There's a sensitivity to running under 'nose', which may be interacting with multiprocessing's fork().

Noted in doc strings that OpenMDAO_Proxy /BaseProxy users should avoid str() or '%s' and use repr() or '%r' instead. Also updated some logging to help debug future issues of this kind.

Updated assert_rel_error() to handle a desired value of zero (used in vsp_wrapper testing)
