### PR TITLE
closes GH-575: Fix broken and redirected links

### DIFF
--- a/docs/dev-checklist.rst
+++ b/docs/dev-checklist.rst
@@ -32,7 +32,7 @@ repository (assuming the maintainers approve the change).
 
     Log into GitHub.
     
-    Go to the issues page: http://github.com/OpenMDAO/OpenMDAO-Framework/issues 
+    Go to the issues page: https://github.com/OpenMDAO/OpenMDAO-Framework/issues 
     
     Select the **New Issue** button and fill out the form. (Some issues are labeled. Only users with admin rights can label an issue.) 
     

--- a/docs/dev-guide/intro.rst
+++ b/docs/dev-guide/intro.rst
@@ -84,7 +84,8 @@ below.
       You can optionally use Visual C++ 2008 as your C++ compiler. You don't need it, mingw32 will work fine,
       but if you prefer Visual C++ 2008, you're welcome to use it instead. The Express version will work, 
       but others (Professional, Standard) should work too. To get this software,
-      go to the `downloads page <http://www.microsoft.com/express/downloads/#2008-Visual-CPP>`_.     
+      go to the `downloads page <http://www.microsoft.com/visualstudio/en-us/products/2010-editions/express/#2008-Visual-CPP>`_.  
+         
          
 .. __: http://sourceforge.net/projects/mingw/files
 
@@ -108,7 +109,7 @@ for information on configuring proxy settings.
 
 The source repository for the OpenMDAO project is available on
 :term:`GitHub`.  There is a wealth of good documentation available online 
-about :term:`git` and Github itself. The 
+about :term:`Git` and Github itself. The 
 `GitHub help page <http://help.github.com/>`_ is a good place to start. If you're a 
 Windows user, make sure to read the details about using Git Bash on the `Windows 
 specific installation instructions <http://help.github.com/win-set-up-git/>`_. 
@@ -183,7 +184,7 @@ account. The following section describes how to register your SSH key with
 GitHub.
 
 These instructions assume that you already have a GitHub account. If you do
-not, please go to http://github.com and register for an account. Go ahead
+not, please go to https://github.com and register for an account. Go ahead
 and log in to your GitHub account, since you will need to be logged in to
 register your key.
 
@@ -232,7 +233,7 @@ Getting the Source Code
 +++++++++++++++++++++++
 
 The *official* OpenMDAO-Framework repository lives on GitHub at
-http://github.com/OpenMDAO/OpenMDAO-Framework. 
+https://github.com/OpenMDAO/OpenMDAO-Framework. 
 
 
 
@@ -262,7 +263,7 @@ Making a Personal Fork of OpenMDAO-Framework
 If you intend to make contributions to the project, you'll need to make your
 own personal fork of OpenMDAO-Framework on GitHub. Making your own fork is
 easy; just log into GitHub, go to the OpenMDAO-Framework repository page at
-http://github.com/OpenMDAO/OpenMDAO-Framework, and click the *Fork* button
+https://github.com/OpenMDAO/OpenMDAO-Framework, and click the *Fork* button
 near the top of the page.
 
 Later, when you finish working on a branch in your local repository, you'll be

--- a/docs/dev-guide/issues.rst
+++ b/docs/dev-guide/issues.rst
@@ -14,7 +14,7 @@ for the project, but you can also create a new issue yourself.
 To create a GitHub issue, follow these steps:
 
 
-1.  First, log into GitHub and go to http://github.com/OpenMDAO/OpenMDAO-Framework/issues. 
+1.  First, log into GitHub and go to https://github.com/OpenMDAO/OpenMDAO-Framework/issues. 
     (You must be logged in to create a new issue.)
 
 2.  Select the the **New Issue** button in the upper right hand corner. 

--- a/docs/dev-guide/scripts.rst
+++ b/docs/dev-guide/scripts.rst
@@ -93,10 +93,10 @@ a **-h** option shows the following:
                       temporary build directory. If testing on EC2, stop 
                       the instance instead of terminating it. 
        -f FNAME, --file=FNAME
-                      Pathname of a tarfile or URL of a git repo. 
+                      Pathname of a tarfile or URL of a Git repo. 
                       Defaults to the current repo.
        -b BRANCH, --branch=BRANCH
-                      If file is a git repo, supply branch name here
+                      If file is a Git repo, supply branch name here
 
 
 The tests run concurrently and write their outputs to 
@@ -106,9 +106,9 @@ and *host_config_name* is the section name for that host in the config file.
 The --host arg can be used multiple times in order to specify more than one
 host.
 
-The script can test the current (committed) branch of a git repository, 
+The script can test the current (committed) branch of a Git repository, 
 a tarred repository, or a specific branch of a specified local or remote git 
-repository.  If a git repository is specified rather than a tar file, then
+repository.  If a Git repository is specified rather than a tar file, then
 the branch must also be specified.  If no **-f** is supplied, the current
 branch of the current repository is used.
 
@@ -228,4 +228,4 @@ a local directory path if you need to debug or test the process outside
 of the production environment.  This is actually what *test_release* does
 when you supply it with a release directory.
 
-The last step is to update the repository on github...
+The last step is to update the repository on GitHub ...

--- a/docs/dev-guide/testing.rst
+++ b/docs/dev-guide/testing.rst
@@ -8,7 +8,7 @@ Testing
 
 By default, your top level ``devenv/bin`` directory will contain a script
 called ``openmdao_test`` that uses a Python package called `nose
-<http://somethingaboutorange.com/mrl/projects/nose/0.11.2>`_ to run all of the unit
+<http://readthedocs.org/docs/nose/en/latest/>`_ to run all of the unit
 tests for any package that you specify. For example, to run the full set
 of openmdao unit tests, type:
 

--- a/docs/plugin-guide/filewrapper_plugin.rst
+++ b/docs/plugin-guide/filewrapper_plugin.rst
@@ -519,7 +519,7 @@ one of the community-developed engines, such as mako_ or django_.
 
 .. _mako: http://www.makotemplates.org/
 
-.. _django: http://docs.djangoproject.com/en/dev/topics/templates/
+.. _django: https://docs.djangoproject.com/en/dev/topics/templates/
 
 .. todo:: Include some examples with one of the templating engines.
 


### PR DESCRIPTION
Fixed 2 broken links and modified 7 redirected links. Two other redirected links cannot be changed because they relate to licenses, which are automatically pulled into the table. Also capitalized "Git" in a couple of place for consistency.
