### PR TITLE
Closes #610: Don't do metadata checks with File variables if iotype is None.

### DIFF
--- a/openmdao.lib/src/openmdao/lib/datatypes/file.py
+++ b/openmdao.lib/src/openmdao/lib/datatypes/file.py
@@ -28,9 +28,8 @@ class File(Variable):
             if not isinstance(default_value, FileRef):
                 raise TypeError('File default value must be a FileRef.')
             
-        if iotype is None:
-            raise ValueError("File must have 'iotype' defined.")
-        metadata['iotype'] = iotype
+        if iotype is not None:
+            metadata['iotype'] = iotype
         
         # Put desc in the metadata dictionary
         if desc is not None:
@@ -50,9 +49,12 @@ class File(Variable):
                     if name in meta:
                         del meta[name]
                 default_value = FileRef(path, **meta)
-        else:
+
+        elif iotype == 'in':
             if 'path' in metadata:
                 raise ValueError("'path' invalid for input File.")
+
+        # iotype of None => we can't check anything.
             
         super(File, self).__init__(default_value, **metadata)
 

--- a/openmdao.main/src/openmdao/main/test/test_filevar.py
+++ b/openmdao.main/src/openmdao/main/test/test_filevar.py
@@ -274,14 +274,6 @@ class TestCase(unittest.TestCase):
             self.fail('Expected Exception')
 
         try:
-            File()
-        except Exception, exc:
-            self.assertEqual(str(exc),
-                             "File must have 'iotype' defined.")
-        else:
-            self.fail('Expected Exception')
-
-        try:
             File(iotype='out')
         except Exception, exc:
             self.assertEqual(str(exc),

--- a/openmdao.main/src/openmdao/main/test/test_objserverfactory.py
+++ b/openmdao.main/src/openmdao/main/test/test_objserverfactory.py
@@ -12,6 +12,7 @@ import time
 import unittest
 import nose
 
+from openmdao.main.component import SimulationRoot
 from openmdao.main.objserverfactory import ObjServerFactory, ObjServer, \
                                            start_server
 from openmdao.util.testutil import assert_raises
@@ -62,7 +63,7 @@ class TestCase(unittest.TestCase):
         finally:
             if factory is not None:
                 factory.cleanup()
-            os.chdir('..')
+            SimulationRoot.chroot('..')
             if sys.platform == 'win32':
                 time.sleep(2)  # Wait for process shutdown.
             keep_dirs = int(os.environ.get('OPENMDAO_KEEPDIRS', '0'))
@@ -178,7 +179,7 @@ class TestCase(unittest.TestCase):
                 self.fail('Expected TypeError')
 
         finally:
-            os.chdir('..')
+            SimulationRoot.chroot('..')
             shutil.rmtree(testdir)
 
     def test_shell(self):
@@ -230,7 +231,7 @@ class TestCase(unittest.TestCase):
                           globals(), locals(), ValueError,
                           "'no-such-egg' not found.")
         finally:
-            os.chdir('..')
+            SimulationRoot.chroot('..')
             shutil.rmtree(testdir)
 
 


### PR DESCRIPTION
Retains existing capabilities when not inside a VariableTree.
Inside a VariableTree matadata will be supported if specified, but isn't required.

Change to test_objserverfactory.py fixes a current directory side-effect.
