### PR TITLE
Closes #621: Purge stale credentials attached to main thread in test_publickey.py

### DIFF
--- a/openmdao.util/src/openmdao/util/test/test_publickey.py
+++ b/openmdao.util/src/openmdao/util/test/test_publickey.py
@@ -1,5 +1,5 @@
 """
-Test mp_util.py
+Test publickey.py
 """
 
 import logging
@@ -7,6 +7,7 @@ import os.path
 import getpass
 import socket
 import sys
+import threading
 import unittest
 import nose
 
@@ -47,6 +48,13 @@ class TestCase(unittest.TestCase):
             else:
                 public_file = '/bin/sh'
             self.assertFalse(is_private(public_file))
+
+        # We've clobbered the existing credentials key data, so be
+        # sure no stale credentials are in use.
+        try:
+            del threading.current_thread().credentials
+        except AttributeError:
+            pass
 
     def test_authorized_keys(self):
         logging.debug('')


### PR DESCRIPTION
Apparently data attached to a thread is handled differently in Py2.7.  test_publickey.py clobbers existing key data.  In Py2.6 this wasn't a problem because new servers started apparently inherited the main thread's credentials across the multiprocessing fork.  In 2.7 no credential data is inherited, so new servers would get credentials from the key data updated by test_publickey.py.  There would now be a credential mismatch between the thread starting the server and the server thread, resulting in the errors reported by test_distsim.py.
