### PR TITLE
closes GH-627: Update Dev Guide and Dev Checklist. Fixed checklist number

### DIFF
--- a/docs/dev-checklist.rst
+++ b/docs/dev-checklist.rst
@@ -105,7 +105,7 @@ repository (assuming the maintainers approve the change).
 
     Fix any errors found during testing.
 
-10. Change the docs if needed. (For more information on creating or updating docs, see
+11. Change the docs if needed. (For more information on creating or updating docs, see
     :ref:`resources`.)  
 
     To build and then display the docs, use the following scripts:
@@ -116,7 +116,7 @@ repository (assuming the maintainers approve the change).
       openmdao_docs
 
 
-11. Test the docs. 
+12. Test the docs. 
                  	 
     ::
     
@@ -127,20 +127,20 @@ repository (assuming the maintainers approve the change).
 
     Fix errors if any.
 
-12. If you have not done so, visually inspect the docs using the default browser. 
+13. If you have not done so, visually inspect the docs using the default browser. 
                  
 		 
     ::
      
       openmdao_docs
 
-13.  Stage the updated content for the next commit.
+14.  Stage the updated content for the next commit.
                  
      ::
      
        git add .
 
-14. Commit the staged content. (The ``-a`` will include any changes that you forgot to explicitly add to the
+15. Commit the staged content. (The ``-a`` will include any changes that you forgot to explicitly add to the
     staging area with ``git add``.) Use the issue number from Step 1 in your comment. 
     
     ::

--- a/docs/dev-guide/index.rst
+++ b/docs/dev-guide/index.rst
@@ -12,7 +12,6 @@ Developer Guide
    working
    issues
    testing
-   scripts
    git
    todo
    

--- a/docs/documenting/updating.rst
+++ b/docs/documenting/updating.rst
@@ -144,7 +144,6 @@ See the example that follows.
         licenses/index
         documenting/index
 
-
 Use your text editor to add ``new-guide/index`` to the desired location in the project's
 ``index.rst`` and then save the file. 
 


### PR DESCRIPTION
closes GH-627: Update Dev Guide and Dev Checklist. Fixed checklist numbering; removed info on
remote testing/building and releasing from Dev Guide.
