### PR TITLE
Fixed problem with accessing attributes within an input or output data object

### DIFF
--- a/openmdao.lib/src/openmdao/lib/drivers/test/test_caseiterdriver.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/test/test_caseiterdriver.py
@@ -305,7 +305,7 @@ class TestCase(unittest.TestCase):
 
         self.assertEqual(len(results), len(cases))
         msg = "driver: Exception getting case outputs: " \
-            "driven: object has no attribute 'sum_z'"
+            "driven: 'DrivenComponent' object has no attribute 'sum_z'"
         for case in results.cases:
             self.assertEqual(case.msg, msg)
 

--- a/openmdao.lib/src/openmdao/lib/drivers/test/test_doedriver.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/test/test_doedriver.py
@@ -164,7 +164,7 @@ class TestCase(unittest.TestCase):
 
         self.assertEqual(len(results), self.model.driver.DOEgenerator.num_sample_points)
         msg = "driver: Exception getting case outputs: " \
-            "driven: object has no attribute 'sum_z'"
+            "driven: 'DrivenComponent' object has no attribute 'sum_z'"
         for case in results.cases:
             self.assertEqual(case.msg, msg)
 
@@ -218,7 +218,7 @@ class TestCase(unittest.TestCase):
             a.run()
         except Exception as err:
             self.assertTrue(str(err).startswith('driver: Run aborted: Traceback '))
-            self.assertTrue(str(err).endswith("d: object has no attribute 'bad'"))
+            self.assertTrue(str(err).endswith("d: 'Dummy' object has no attribute 'bad'"))
         else:
             self.fail("Exception expected")
 

--- a/openmdao.main/src/openmdao/main/test/test_container.py
+++ b/openmdao.main/src/openmdao/main/test/test_container.py
@@ -14,7 +14,9 @@ from openmdao.main.container import Container, get_default_name, \
                                     deep_hasattr, get_default_name, find_name, \
                                     find_trait_and_value, _get_entry_group, \
                                     create_io_traits
+from openmdao.main.uncertain_distributions import NormalDistribution
 from openmdao.main.variable import Variable
+from openmdao.main.slot import Slot
 from openmdao.lib.datatypes.api import Float, Int, Bool, List, Dict
 from openmdao.util.testutil import make_protected_dir
 
@@ -30,8 +32,11 @@ class DumbTrait(Variable):
         return value
 
 class MyContainer(Container):
+    uncertain = Slot(NormalDistribution(), iotype="out")
+
     def __init__(self, *args, **kwargs):
         super(MyContainer, self).__init__(*args, **kwargs)
+        self.uncertain = NormalDistribution()
         self.add('dyntrait', Float(9., desc='some desc'))
 
 
@@ -141,6 +146,11 @@ class ContainerTestCase(unittest.TestCase):
             self.assertEqual(str(err), "'MyClass' object has no attribute 'foo'")
         else:
             self.fail("expected AttributeError")
+            
+    def test_attrib_metadata(self):
+        cont = MyContainer()
+        io = cont.get_metadata('uncertain.mu', 'iotype')
+        self.assertEqual(io, 'out')
         
     def test_deep_hasattr(self):
         class MyClass(object):

--- a/openmdao.main/src/openmdao/main/test/test_evalexpr.py
+++ b/openmdao.main/src/openmdao/main/test/test_evalexpr.py
@@ -494,7 +494,7 @@ class ExprEvalTestCase(unittest.TestCase):
         try:
             ex.evaluate(self.top.a)
         except AttributeError as err:
-            self.assertEqual(str(err), "can't evaluate expression 'comp.y': a: object has no attribute 'comp.y'")
+            self.assertEqual(str(err), "can't evaluate expression 'comp.y': a: 'A' object has no attribute 'comp'")
         else:
             self.fail("AttributeError expected")
         ex.scope = self.top
@@ -624,7 +624,7 @@ class ExprEvalTestCase(unittest.TestCase):
             ex = ExprEvaluator('abcd.efg', self.top)
             ex.evaluate()
         except AttributeError, err:
-            self.assertEqual(str(err), "can't evaluate expression 'abcd.efg': : object has no attribute 'abcd.efg'")
+            self.assertEqual(str(err), "can't evaluate expression 'abcd.efg': : 'Assembly' object has no attribute 'abcd'")
         else:
             raise AssertionError('AttributeError expected')
         


### PR DESCRIPTION
Driver parameters/objectives/constraints can now access attributes within a data object, e.g., a NormalDistribution object.
