### PR TITLE
VariableTree update problem

### DIFF
--- a/openmdao.main/src/openmdao/main/assembly.py
+++ b/openmdao.main/src/openmdao/main/assembly.py
@@ -168,6 +168,9 @@ class Assembly (Component):
         except ValueError:
             return (None, self, path)
         
+        t = self.get_trait(compname)
+        if t and t.iotype:
+            return (None, self, path)
         return (compname, getattr(self, compname), varname)
 
     @rbac(('owner', 'user'))

--- a/openmdao.main/src/openmdao/main/container.py
+++ b/openmdao.main/src/openmdao/main/container.py
@@ -315,10 +315,13 @@ class Container(HasTraits):
         if self._cached_traits_ is None:
             self._cached_traits_ = self.traits()
             self._cached_traits_.update(self._instance_traits())
-        trait = self._cached_traits_.get(name)
-        if copy and trait:
-            return self.trait(name, copy=copy)
-        return trait
+        if copy:
+            if self._cached_traits_.get(name):
+                return self.trait(name, copy=copy)
+            else:
+                return None
+        else:
+            return self._cached_traits_.get(name)
 
     #
     #  HasTraits overrides
@@ -407,8 +410,7 @@ class Container(HasTraits):
 
     def add_trait(self, name, trait):
         """Overrides HasTraits definition of *add_trait* in order to
-        keep track of dynamically added traits for serialization and to add
-        callbacks for input Variables.
+        keep track of dynamically added traits for serialization.
         """
         # When a trait with sub-traits is added (like a List or Dict),
         # HasTraits calls add_trait AGAIN for the sub-trait, so we
@@ -427,9 +429,6 @@ class Container(HasTraits):
         """Overrides HasTraits definition of remove_trait in order to
         keep track of dynamically added traits for serialization.
         """
-        ## this just forces the regeneration (lazily) of the lists of
-        ## inputs, outputs, and containers
-        #self._trait_added_changed(name)
         try:
             del self._added_traits[name]
         except KeyError:

--- a/openmdao.main/src/openmdao/main/vartree.py
+++ b/openmdao.main/src/openmdao/main/vartree.py
@@ -17,6 +17,10 @@ class VariableTree(Container):
         super(VariableTree, self).__init__(doc=doc)
         self._iotype = iotype
         self.on_trait_change(self._iotype_modified, '_iotype')
+        # register callbacks for our class traits
+        for name,trait in self.class_traits().items():
+            if not name.startswith('_'):
+                self.on_trait_change(self._trait_modified, name)
 
     @property
     def iotype(self):


### PR DESCRIPTION
fixed bug where parameter set inside of a VariableTree was not flagging the parent component for execution.  

closes #722
