### PR TITLE
Fixes 724 - Complex unit strings with prefixes don't work

### DIFF
--- a/openmdao.units/openmdao/units/test/test_units.py
+++ b/openmdao.units/openmdao/units/test/test_units.py
@@ -175,16 +175,26 @@ class test__PhysicalQuantity(unittest.TestCase):
 
 
     def test_currency_unit(self):
+        # probably don't need this test, since I changed $ to USD
         try:
-            x = units.PhysicalQuantity('1$')
+            x = units.PhysicalQuantity('1USD')
         except ValueError:
-            self.fail("Error: Currency Unit ($) is not working")
+            self.fail("Error: Currency Unit (USD) is not working")
         
     def test_hour_unit(self):
         # Added to test problem in Ticket 466
         x = units.PhysicalQuantity('7200s')
         x.convert_to_unit('h')
-        self.assertEqual(x,units.PhysicalQuantity('2h'))
+        self.assertEqual(x, units.PhysicalQuantity('2h'))
+        
+    def test_prefix_plus_math(self):
+        # From an issue: m**2 converts find, but cm**2 does not.
+        
+        x1 = units.convert_units(1.0, 'm**2', 'cm**2')
+        self.assertEqual(x1, 10000.0)
+        
+        # Let's make sure we can dclare some complicated units
+        x = units.PhysicalQuantity('7200nm**3/kPa*dl')
         
     def test_add_known_Values(self):
         """addition should give known result with known input. 

--- a/openmdao.units/openmdao/units/unitLibdefault.ini
+++ b/openmdao.units/openmdao/units/unitLibdefault.ini
@@ -30,7 +30,7 @@ amount: mol
 luminous_intesity: cd
 angle: rad
 solid_angle: sr
-money: $
+money: USD
 passengers: pax
 
 [units]

--- a/openmdao.units/openmdao/units/units.py
+++ b/openmdao.units/openmdao/units/units.py
@@ -550,31 +550,35 @@ def _find_unit(unit):
                 unit = eval(name, {'__builtins__':None}, _unit_lib.unit_table)
             except: 
                 
-                #check for single letter prefix before unit
-                if(name[0] in _unit_lib.prefixes and \
-                   name[1:] in _unit_lib.unit_table):
-                    add_unit(unit, _unit_lib.prefixes[name[0]]* \
-                                  _unit_lib.unit_table[name[1:]])
+                # This unit might include prefixed units that aren't in the
+                # unit_table. We must parse them ALL and add them to the
+                # unit_table.
+                
+                # First character of a unit is always alphabet or $.
+                # Remaining characters may include numbers.
+                regex = re.compile('[A-Z,a-z].[A-Z,a-z,0-9]*')
+                
+                for item in regex.findall(name):
                     
-                #check for double letter prefix before unit
-                elif(name[0:2] in _unit_lib.prefixes and \
-                     name[2:] in _unit_lib.unit_table):
-                    add_unit(unit, _unit_lib.prefixes[name[0:2]]* \
-                                  _unit_lib.unit_table[name[2:]])
+                    #check for single letter prefix before unit
+                    if(item[0] in _unit_lib.prefixes and \
+                       item[1:] in _unit_lib.unit_table):
+                        add_unit(item, _unit_lib.prefixes[item[0]]* \
+                                 _unit_lib.unit_table[item[1:]])
                     
-                #no prefixes found, unknown unit
-                else:
+                    #check for double letter prefix before unit
+                    elif(item[0:2] in _unit_lib.prefixes and \
+                         item[2:] in _unit_lib.unit_table):
+                        add_unit(item, _unit_lib.prefixes[item[0:2]]* \
+                                  _unit_lib.unit_table[item[2:]])
                     
-                    # Hack for currency, since $ is not a valid python var
-                    if name[0] == "$":
-                        unit = name[0]
-                        return unit
+                    #no prefixes found, unknown unit
                     else:
-                        raise ValueError, "no unit named '%s' is defined" % name
+                        raise ValueError, "no unit named '%s' is defined" % item
             
                 unit = eval(name, {'__builtins__':None}, _unit_lib.unit_table)
         
-            _unit_cache[name] = unit
+                _unit_cache[name] = unit
 
     if not isinstance(unit, PhysicalUnit):
         raise TypeError(str(unit) + ' is not a unit')


### PR DESCRIPTION
Some improvements to the units code to fix a problem that prevented the parsing of complicated units expressions built up from prefixed base units.

Also, the $ (currency) unit has been replaced with USD
