### PR TITLE
Closes #765: Add missing allow_tunneling attribute to OpenMDAO_Server.

### DIFF
--- a/openmdao.main/src/openmdao/main/mp_support.py
+++ b/openmdao.main/src/openmdao/main/mp_support.py
@@ -174,6 +174,7 @@ class OpenMDAO_Server(Server):
         else:
             self._allowed_hosts = allowed_hosts or []
 
+        self._allow_tunneling = allow_tunneling
         if allow_tunneling and '127.0.0.1' not in self._allowed_hosts:
             self._allowed_hosts.append('127.0.0.1')
 


### PR DESCRIPTION
Unclear how this went missing when Chris Heath is presumably using tunneling.  Possibly he's still using the development code and this somehow got dropped on it's way to release.
