### PR TITLE
closes GH-766: added routine to get unused IP port

### DIFF
--- a/openmdao.util/src/openmdao/util/network.py
+++ b/openmdao.util/src/openmdao/util/network.py
@@ -1,0 +1,17 @@
+"""
+Routines to help out with obtaining debugging information
+"""
+
+import socket
+
+def get_unused_ip_port():
+    '''find an unused IP port    
+       ref: http://code.activestate.com/recipes/531822-pick-unused-port/
+       note: use the port before it is taken by some other process!
+       '''
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(('localhost', 0))
+    sockname = sock.getsockname()
+    sock.close()
+    return sockname[1] # port number
+

--- a/openmdao.util/src/openmdao/util/test/test_network.py
+++ b/openmdao.util/src/openmdao/util/test/test_network.py
@@ -1,0 +1,26 @@
+"""
+Test Network Functions
+"""
+import unittest
+
+from openmdao.util.network import get_unused_ip_port
+
+class NetworkTestCase(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_get_unused_ip_port(self):
+        ip_port = get_unused_ip_port()
+        self.assertTrue( isinstance( ip_port, int ) )
+        # actually, in practice the range does not go that low but it varies from system to system
+        self.assertTrue( ip_port >= 1024 ) 
+        self.assertTrue( ip_port <= 65535 )
+        
+        
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Added a simple function to get an unused IP port for use with the GUI and GUI testing. Maybe other uses later. 
