### PR TITLE
Closes GH-654: Fix Sphinx 1.1 warnings. 

### DIFF
--- a/docs/srcdocs/index.rst
+++ b/docs/srcdocs/index.rst
@@ -27,6 +27,14 @@ Source Documentation
 
 .. _openmdao.main.datatypes.float.py:
 
+.. _openmdao.lib.doegenerators.api:
+
+.. _doedriver.py: 
+
+.. _fullfactorial.py: 
+
+.. _openmdao.lib.casehandler.api.py: 
+
 
 .. toctree::
    :maxdepth: 3 


### PR DESCRIPTION
In docs/srcdocs/index.rst, added labels (following Bret's format) for files that were causing warnings. (Note: cannot  upgrade Sphinx version until dependencies addressed.)
