### PR TITLE
Changed behavior of Fixed Point Iterator - max iterations now gives warn...

### DIFF
--- a/openmdao.lib/src/openmdao/lib/drivers/docs/iterate.rst
+++ b/openmdao.lib/src/openmdao/lib/drivers/docs/iterate.rst
@@ -78,7 +78,7 @@ single-output method, so it is only valid to specify one constraint and one para
 Two additional parameters control the FixedPointIterator. The
 parameter ``tolerance`` sets the convergence tolerance for the comparison
 between value of ``x_out`` at the current iteration and the previous iteration.
-The default value for ``tolerance`` is 0.00001. The parameter ``max_iteration``
+The default value for ``tolerance`` is 0.001. The parameter ``max_iteration``
 specifies the number of iterations to run. The default value for
 ``max_iterations`` is 25.
 

--- a/openmdao.lib/src/openmdao/lib/drivers/iterate.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/iterate.py
@@ -35,7 +35,7 @@ class FixedPointIterator(Driver):
     max_iteration = Int(25, iotype='in', desc='Maximum number of '
                                          'iterations before termination.')
     
-    tolerance = Float(1.0e-5, iotype='in', desc='Absolute convergence '
+    tolerance = Float(1.0e-3, iotype='in', desc='Absolute convergence '
                                             'tolerance between iterations.')
     
     norm_order = Enum('Infinity', ['Infinity', 'Euclidean'], 
@@ -89,8 +89,10 @@ class FixedPointIterator(Driver):
             # check max iteration
             if self.current_iteration >= self.max_iteration-1:
                 self.history = history[:self.current_iteration+1, :]
-                self.raise_exception('Max iterations exceeded without ' + \
-                                     'convergence.', RuntimeError)
+                
+                self._logger.warning('Max iterations exceeded without ' + \
+                                     'convergence.')
+                return
                 
             # Pass output to input
             val0 += history[self.current_iteration, :]

--- a/openmdao.lib/src/openmdao/lib/drivers/test/test_iterate.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/test/test_iterate.py
@@ -116,33 +116,10 @@ class FixedPointIteratorTestCase(unittest.TestCase):
         self.top.driver.add_constraint('simple.outvar - simple.invar = 0')
         self.top.driver.add_parameter('simple.invar', -9e99, 9e99)
         self.top.driver.max_iteration = 3
-        try:
-            self.top.run()
-        except RuntimeError, err:
-            self.assertEqual(str(err), 'driver: Max iterations exceeded ' + \
-                                       'without convergence.' )
-        else:
-            self.fail('RuntimeError expected')
         
-    def test_tolerance(self):
-        self.top.add("driver", FixedPointIterator())
-        self.top.add("simple", Simple3())
-        self.top.driver.workflow.add('simple')
-        self.top.driver.add_constraint('simple.outvar - simple.invar = 0')
-        self.top.driver.add_parameter('simple.invar', -9e99, 9e99)
-        self.top.driver.max_iteration = 2
-        self.top.driver.tolerance = .001
-        try:
-            self.top.run()
-        except RuntimeError, err:
-            self.assertEqual(str(err), 'driver: Max iterations exceeded ' + \
-                                       'without convergence.' )
-        else:
-            self.fail('RuntimeError expected')   
-            
-        self.top.driver.tolerance = 0.1
         self.top.run()
-
+        self.assertEqual(self.top.driver.current_iteration, 2)
+        
     def test_check_config(self):
         self.top.add("driver", FixedPointIterator())
         self.top.add("simple", Multi())


### PR DESCRIPTION
Changed two things on the FixedPointIterator

1) Tolerance loosened to 1e-3, which seems to be better for real cases

2) Behavior changed so that a warning is logged if the maximum iterations is hit without convergence. This is more consistent with our other drivers, though all of this will have to be revisited someday when we implement user-defined "smarts" for handling solver failures.
