### PR TITLE
closes #786  closes #781 fixed a bug and an inconsistency in the units lib

### DIFF
--- a/openmdao.units/openmdao/units/test/test_units.py
+++ b/openmdao.units/openmdao/units/test/test_units.py
@@ -181,6 +181,14 @@ class test__PhysicalQuantity(unittest.TestCase):
         except ValueError:
             self.fail("Error: Currency Unit (USD) is not working")
         
+    def test_pi(self):
+        # Fixes issue 786
+        x = units.PhysicalQuantity('1rpm')
+        x.convert_to_unit('rad/min')
+        self.assertAlmostEqual(x.value,
+                               units.PhysicalQuantity('6.283185rad/min').value,
+                               places=3)
+        
     def test_hour_unit(self):
         # Added to test problem in Ticket 466
         x = units.PhysicalQuantity('7200s')

--- a/openmdao.units/openmdao/units/unitLibdefault.ini
+++ b/openmdao.units/openmdao/units/unitLibdefault.ini
@@ -58,8 +58,6 @@ lx: lm/m**2,Lux
 Bq: 1/s,Becquerel
 Gy: J/kg,Gray
 Sv: J/kg,Sievert
-m2: m**2,Square Meter
-m3: m**3,Cubic Meter
 min: 60*s,Minute
 h: 3600*s,Hour
 d: 86400*s,Day
@@ -120,7 +118,6 @@ Grav:6.67259e-11*m**3/kg/s**2,universal gravitational constant
 e:1.60217733e-19*C,elementry charge
 me: 9.1093897e-31*kg,electron mass
 Nav: 6.0221367e23/mol,Avagadros number
-pi: 3.141592653589*rad,pi
 R: 8.31424*J/(mol*degK), gas constant
 V0: 2.24136*m**3/(1000*mol), volume of ideal gas
 u: 1.660531e-27*kg, unified atomic mass unit

--- a/openmdao.units/openmdao/units/units.py
+++ b/openmdao.units/openmdao/units/units.py
@@ -19,7 +19,7 @@ Justin Gray."""
 import re, ConfigParser
 import os.path
 
-from math import sin, cos, tan, floor
+from math import sin, cos, tan, floor, pi
 
 # pylint: disable-msg=E0611,F0401, E1101
 try: 
@@ -615,7 +615,8 @@ def add_unit(name, unit, comment=''):
     if comment:
         _unit_lib.help.append((name, comment, unit))
     if isinstance(unit, str):
-        unit = eval(unit, {'__builtins__':None}, _unit_lib.unit_table)
+        unit = eval(unit, {'__builtins__':None, 'pi':pi},
+                           _unit_lib.unit_table)
     unit.set_name(name)
     if name in _unit_lib.unit_table:
         if (_unit_lib.unit_table[name].factor!=unit.factor or \


### PR DESCRIPTION
closes #786
closes #781

1.) Removed pi from the unitdefaults.lib. Added math.pi to the globals dictionary that is passed to the initial eval() call in _add_units. This way, pi always comes from Python with the correct number of places for that system architecture.

2) Removed m2 and m3 for consistency. One should always use m**2 and m**3.
