### PR TITLE
closes #788 No longer increment exec_count when a component uses its derivatives to generate an output

### DIFF
--- a/openmdao.main/src/openmdao/main/component.py
+++ b/openmdao.main/src/openmdao/main/component.py
@@ -370,8 +370,6 @@ class Component (Container):
         Overrides of this function must call this version.  This is only 
         called if execute() actually ran.
         """
-        self.exec_count += 1
-        
         # make our output Variables valid again
         valids = self._valid_dict
         for name in self.list_outputs(valid=False):
@@ -431,6 +429,7 @@ class Component (Container):
                 else:
                     # Component executes as normal
                     self.execute()
+                    self.exec_count += 1
                     
                 self._post_execute()
             #else:

--- a/openmdao.main/src/openmdao/main/test/test_derivatives.py
+++ b/openmdao.main/src/openmdao/main/test/test_derivatives.py
@@ -513,7 +513,10 @@ class DerivativesTestCase(unittest.TestCase):
         self.assertEqual(comp.A3.ran_real, True)
         self.assertEqual(comp.A4.ran_real, False)
         self.assertEqual(comp.A5.ran_real, True)
-
+        self.assertEqual(comp.A1.exec_count, 5)
+        self.assertEqual(comp.A2.exec_count, 1)
+        self.assertEqual(comp.A4.exec_count, 1)
+        self.assertEqual(comp.A5.exec_count, 5)
         
 # Next up: test to make sure that we can pass tuples of parameters through assembly
 # without tripping up its check_derivatives 


### PR DESCRIPTION
Moved exec_count so that it only increments when a component actually runs it's execute function, and not when it uses its derivatives to calculate outputs.
