### PR TITLE
Closes #842: Spaces in username cause test_distsim failures

### DIFF
--- a/openmdao.main/src/openmdao/main/grid_engine.py
+++ b/openmdao.main/src/openmdao/main/grid_engine.py
@@ -395,6 +395,7 @@ class GridEngineServer(ObjServer):
                 'start_time',
                 'accounting_id')
 
+        email_events = ''
         for key in keys:
             try:
                 value = resource_desc[key]
@@ -411,9 +412,9 @@ class GridEngineServer(ObjServer):
             elif key == 'email':
                 cmd.extend(('-M', ','.join(value)))
             elif key == 'email_on_started':
-                cmd.extend(('-m', 'b'))
+                email_events += 'b'
             elif key == 'email_on_terminated':
-                cmd.extend(('-m', 'e'))
+                email_events += 'e'
             elif key == 'job_name':
                 cmd.extend(('-N', self._jobname(value)))
             elif key == 'input_path':
@@ -439,6 +440,9 @@ class GridEngineServer(ObjServer):
                 cmd.extend(('-a', value.strftime('%Y%m%d%H%M.%S')))
             elif key == 'accounting_id':
                 cmd.extend(('-A', value))
+
+        if email_events:
+            cmd.extend(('-m', email_events))
 
         # Setup parallel environment.
         if 'job_category' in resource_desc:

--- a/openmdao.main/src/openmdao/main/mp_support.py
+++ b/openmdao.main/src/openmdao/main/mp_support.py
@@ -431,7 +431,7 @@ class OpenMDAO_Server(Server):
                                            credentials)
                 if methodname != 'echo':
                     # 'echo' is used for performance tests, keepalives, etc.
-                    self._logger.debug('Invoke %s %s %s',
+                    self._logger.debug("Invoke %s %s '%s'",
                                        methodname, role, credentials)
 #                    self._logger.debug('       %s %s', args, kwds)
 
@@ -884,9 +884,9 @@ class OpenMDAO_Manager(BaseManager):
             if sys.platform == 'win32' and not HAVE_PYWIN32:  #pragma no cover
                 timeout = 120
             else:
-                timeout = 5
+                timeout = 10
         else:
-            timeout = 5
+            timeout = 10
 
         writer.close()
         start = time.time()

--- a/openmdao.main/src/openmdao/main/pbs.py
+++ b/openmdao.main/src/openmdao/main/pbs.py
@@ -364,6 +364,7 @@ class PBS_Server(ObjServer):
                     'priority',
                     'start_time')
 
+            email_events = ''
             for key in keys:
                 try:
                     value = resource_desc[key]
@@ -382,9 +383,9 @@ class PBS_Server(ObjServer):
                 elif key == 'email':
                     script.write('%s -M %s\n' % (prefix, ','.join(value)))
                 elif key == 'email_on_started':
-                    script.write('%s -m b\n' % prefix)
+                    email_events += 'b'
                 elif key == 'email_on_terminated':
-                    script.write('%s -m e\n' % prefix)
+                    email_events += 'e'
                 elif key == 'job_name':
                     script.write('%s -N %s\n' % (prefix, self._jobname(value)))
                 elif key == 'input_path':
@@ -402,6 +403,9 @@ class PBS_Server(ObjServer):
                 elif key == 'start_time':
                     script.write('%s -a %s\n'
                                  % (prefix, value.strftime('%Y%m%d%H%M.%S')))
+
+            if email_events:
+                script.write('%s -m %s\n' % (prefix, email_events))
 
             # Set resource limits.
             if 'resource_limits' in resource_desc:

--- a/openmdao.main/src/openmdao/main/test/test_distsim.py
+++ b/openmdao.main/src/openmdao/main/test/test_distsim.py
@@ -509,7 +509,7 @@ class TestCase(unittest.TestCase):
         # This 'spook' creation is only for testing.
         # Normally the protector would run with regular credentials
         # in effect at the proprietary site.
-        user = 'spooky@'+socket.gethostname()
+        user = 'i am a spy@'+socket.gethostname()
         key_pair = get_key_pair(user)
         data = '\n'.join([user, '0', key_pair.publickey().exportKey()])
         hash = hashlib.sha256(data).digest()

--- a/openmdao.main/src/openmdao/main/test/test_gridengine.py
+++ b/openmdao.main/src/openmdao/main/test/test_gridengine.py
@@ -149,7 +149,7 @@ class TestCase(unittest.TestCase):
             lines = inp.readlines()
         actual = ''.join(lines)
         expected = """\
--V -sync yes -b yes -wd . -h -r yes -M user1@host1,user2@host2 -m b -m e -N TestJob -i echo.in -o echo.out -j yes -ar res-1234 -q debug_q -p 42 -a 201202081642.00 -A CFD-R-US -pe ompi 256-512 -l h_cpu=0:0:1 -l h_rt=0:0:2 -ac name=value echo hello world
+-V -sync yes -b yes -wd . -h -r yes -M user1@host1,user2@host2 -N TestJob -i echo.in -o echo.out -j yes -ar res-1234 -q debug_q -p 42 -a 201202081642.00 -A CFD-R-US -m be -pe ompi 256-512 -l h_cpu=0:0:1 -l h_rt=0:0:2 -ac name=value echo hello world
 -V
 -sync arg yes
 -b arg yes
@@ -157,8 +157,6 @@ class TestCase(unittest.TestCase):
 -h
 -r arg yes
 -M arg user1@host1,user2@host2
--m arg b
--m arg e
 -N arg TestJob
 -i stdin echo.in
 -o stdout echo.out
@@ -168,6 +166,7 @@ class TestCase(unittest.TestCase):
 -p arg 42
 -a arg 201202081642.00
 -A arg CFD-R-US
+-m arg be
 -pe ompi 256-512
 -l resource h_cpu=0:0:1
 -l resource h_rt=0:0:2

--- a/openmdao.main/src/openmdao/main/test/test_pbs.py
+++ b/openmdao.main/src/openmdao/main/test/test_pbs.py
@@ -164,12 +164,11 @@ class TestCase(unittest.TestCase):
 %(prefix)s -r y
 %(prefix)s -l select=256:ncpus=1
 %(prefix)s -M user1@host1,user2@host2
-%(prefix)s -m b
-%(prefix)s -m e
 %(prefix)s -N TestJob
 %(prefix)s -q debug_q
 %(prefix)s -p 42
 %(prefix)s -a 201202081642.00
+%(prefix)s -m be
 %(prefix)s -l walltime=0:00:02
 """ % dict(sh1=sh1, prefix=prefix))
         logging.debug('generated script:')

--- a/openmdao.util/src/openmdao/util/publickey.py
+++ b/openmdao.util/src/openmdao/util/publickey.py
@@ -391,16 +391,16 @@ def read_authorized_keys(filename=None, logger=None):
             if not line:
                 continue
 
-            fields = line.split()
-            if len(fields) != 3:
-                logger.error('bad line (require exactly 3 fields):')
-                logger.error(line)
+            key_type, blank, rest = line.partition(' ')
+            if key_type != 'ssh-rsa':
+                logger.error('unsupported key type: %r', key_type)
                 errors += 1
                 continue
 
-            key_type, key_data, user_host = fields
-            if key_type != 'ssh-rsa':
-                logger.error('unsupported key type: %r', key_type)
+            key_data, blank, user_host = rest.partition(' ')
+            if not key_data:
+                logger.error('bad line (missing key data):')
+                logger.error(line)
                 errors += 1
                 continue
 


### PR DESCRIPTION
I was able to reproduce this by creating fake credentials and running the tests.  Without actually creating a user account with spaces in it I can't prove everything is fixed, but a manual scan of the code found no other sensitivities to usernames with spaces.

Also increased the forked server startup timeout and fixed a minor email events bug in the GridEngine and PBS allocators.
