### PR TITLE
Story 24917253: Corrected error messages for failed installations of plugins

### DIFF
--- a/openmdao.main/src/openmdao/main/plugin.py
+++ b/openmdao.main/src/openmdao/main/plugin.py
@@ -959,7 +959,7 @@ def plugin_install(parser, options, args=None):
             try:
                 resp = urllib2.urlopen(url)
             except urllib2.HTTPError:
-                print "\nERROR: plugin named not found in OpenMDAO-Plugins"
+                print "\nERROR: plugin named '%s' not found in OpenMDAO-Plugins" % name
                 exit()
                 
             for line in resp.fp:
@@ -968,8 +968,16 @@ def plugin_install(parser, options, args=None):
                 tags = []
                 for item in text:
                     tags.append(item['name'])
+            try:
+                tags.sort(key=lambda s: map(int, s.split('.')))
+            except ValueError:
+                print "\nERROR: the releases for the plugin named '%s' have not been tagged correctly for installation. You may want to contact the repository owner" % name
+                exit()
                 
-            tags.sort(key=lambda s: map(int, s.split('.')))
+            if not tags:
+                print "\nERROR: plugin named '%s' has no tagged releases. You may want to contact the repository owner to create a tag" % name
+                exit()
+                
             version = tags[-1]
             
         url = 'https://nodeload.github.com/OpenMDAO-Plugins/%s/tarball/%s' % (name, version)


### PR DESCRIPTION
The code now provides better error messages for the cases:
1. The repo has no tags
2. The repo has tags that are not numbers ( e.g. one junk repo I had, had a tag of 'ver1'. the tags should always be numbers only )
3. The repo does not exist. The error was OK but it it was missing a piece so I corrected it
