### PR TITLE
Fix for plugin installation failure

### DIFF
--- a/openmdao.main/src/openmdao/main/plugin.py
+++ b/openmdao.main/src/openmdao/main/plugin.py
@@ -886,6 +886,7 @@ def plugin_build_docs(parser, options, args=None):
     cfg.set('metadata', 'entry_points', 
             _get_entry_points(os.path.join(destdir,'src')))
     
+    templates, class_templates, test_template = _load_templates()
     template_options = _get_template_options(destdir, cfg)
 
     dirstruct = {


### PR DESCRIPTION
Plugins fail to install because of my change to the templates. I've fixed it, but man we really need those plugin tests. 

We should put out a new release to fix this.
