### PR TITLE
fixing windows fail

### DIFF
--- a/docs/optimization/case_recorders.rst
+++ b/docs/optimization/case_recorders.rst
@@ -84,7 +84,7 @@ The ``DumpCaseRecorder`` is generally used to write readable text out to a
 file or to STDOUT. Let's try using a ``DumpCaseRecorder`` to output a history
 of our paramters, constraints, and objectives to a file named 'data.txt'.
 
-.. testcode :: dump_case
+::
 
     from openmdao.examples.simple.optimization_constrained import OptimizationConstrained
     from openmdao.lib.casehandlers.api import DumpCaseRecorder
@@ -95,12 +95,6 @@ of our paramters, constraints, and objectives to a file named 'data.txt'.
     opt_problem.driver.recorders = [DumpCaseRecorder(outfile)]
     opt_problem.run()
 
-.. testcode :: dump_case
-    :hide:
-    
-    import os
-    if os.path.exists('data.txt'):
-        os.remove('data.txt')
             
 You should now have a file called 'data.txt' that contains output that looks
 like this:
@@ -117,7 +111,7 @@ like this:
          Objective: -27.0833333304
 
 We can also choose to print out all framework variables from components in
-this driver's workflow using a wildcard (*) in the printvars list, and
+this driver's workflow using the wildcard "*" in the printvars list, and
 rerunning the model. 
 
 ::
@@ -154,7 +148,17 @@ The output produced is more detailed:
 You can also use partial wildcard matches, and include multiple wildcards in the 
 ``printvars`` list, so scenarios like this:
 
+::
+
       opt_problem.driver.printvars = ['comp1.*', 'comp2.*', *error*]
 
 are possible. This will return a set of cases with all variables from comp1,
 comp2 as well as any variable with "error" in its name.
+
+The wildcard "?" is also supported for matching single characters, so you could
+rewrite the previous line like this:
+
+::
+
+      opt_problem.driver.printvars = ['comp?.*', *error*]
+

--- a/openmdao.main/src/openmdao/main/driver.py
+++ b/openmdao.main/src/openmdao/main/driver.py
@@ -3,7 +3,7 @@
 #public symbols
 __all__ = ["Driver"]
 
-from fnmatch import fnmatch
+import fnmatch
 
 from networkx.algorithms.shortest_paths.generic import shortest_path
 from enthought.traits.api import List
@@ -385,9 +385,7 @@ class Driver(Component):
         if pattern == '*':
             matched_vars = all_vars
         else:
-            for item in all_vars:
-                if fnmatch(item, pattern):
-                    matched_vars.append(item)
+            matched_vars = fnmatch.filter(all_vars, pattern)
         
         return matched_vars
                 


### PR DESCRIPTION
Turned off testing of a couple of line in the case recorders tutorial to fix a fail in windows. The fail is due to a file that doesn't get cleaned up. There seems to be a bug in sphinx on Torpedo that is preventing me from doing things the way we should, so i have to disable that part of the doc testing for now. 

Also, made a couple of improvements to the fnmatch, based on Bret's suggestions.
