### PR TITLE
Add to list of modules for guireqs for linux platform

### DIFF
--- a/go-openmdao-dev.py
+++ b/go-openmdao-dev.py
@@ -1630,7 +1630,12 @@ def after_install(options, home_dir):
     global logger, openmdao_prereqs
     
     reqs = ['SetupDocs==1.0.5', 'docutils==0.8.1', 'Pyevolve==0.6', 'newsumt==1.1.0', 'Pygments==1.3.1', 'ordereddict==1.1', 'boto==2.0rc1', 'pycrypto==2.3', 'paramiko==1.7.7.1', 'decorator==3.2.0', 'Sphinx==1.1.3', 'Fabric==0.9.3', 'Jinja2==2.4', 'Traits==3.3.0', 'nose==0.11.3', 'zope.interface==3.6.1', 'networkx==1.3', 'pyparsing==1.5.2', 'conmin==1.0.1', 'virtualenv==1.6.4', 'argparse==1.2.1', 'cobyla==1.0.1', 'slsqp==1.0.1']
-    guireqs = ['web.py==0.36', 'jsonpickle==0.4.0', 'Django==1.3']
+    # Only linux needs the modules for doing the GUI unit testing at this time
+    if sys.platform.startswith( "linux" ):
+        guireqs = ['web.py==0.36', 'jsonpickle==0.4.0', 'Django==1.3.1',  'easyprocess==0.1.3',
+                   'path.py==2.2.2', 'pyvirtualdisplay==0.0.9', 'lazr.testing==0.1.2a', 'mocker==1.1', 'zope.testrunner==4.0.4', 'zope.exceptions==3.6.1' ]
+    else:
+        guireqs = ['web.py==0.36', 'jsonpickle==0.4.0', 'Django==1.3.1' ]
     
     if options.findlinks is None:
         url = 'http://openmdao.org/dists'


### PR DESCRIPTION
Some extra modules are needed for the gui unit tests to run. Only needed for linux for now
