### PR TITLE
fixed error in predicted_values trait of MultiObjExpectedImprovement

### DIFF
--- a/openmdao.lib/src/openmdao/lib/components/expected_improvement_multiobj.py
+++ b/openmdao.lib/src/openmdao/lib/components/expected_improvement_multiobj.py
@@ -36,7 +36,7 @@ class MultiObjExpectedImprovement(Component):
                     desc="Names of responses to maximize expected improvement around. \
                     Must be NormalDistribution type.")
     
-    predicted_values = Array([0,0],shape=(2,),iotype="in",dtype=NormalDistribution,
+    predicted_values = Array([0,0],iotype="in",dtype=NormalDistribution,
                         desc="CaseIterator which contains NormalDistributions for each \
                         response at a location where you wish to calculate EI.")
     

--- a/openmdao.lib/src/openmdao/lib/components/test/test_expected_improvement_multiobj.py
+++ b/openmdao.lib/src/openmdao/lib/components/test/test_expected_improvement_multiobj.py
@@ -17,7 +17,8 @@ class MultiObjExpectedImprovementTests(unittest.TestCase):
             bests.record(case)
         ei.best_cases = bests
         ei.criteria = ["y1","y2"]
-        ei.predicted_values = [NormalDistribution(mu=1,sigma=1),NormalDistribution(mu=0,sigma=1)]
+        ei.predicted_values = [NormalDistribution(mu=1,sigma=1),
+                               NormalDistribution(mu=0,sigma=1)]
         ei.calc_switch = "EI"
         ei.execute()
         self.assertAlmostEqual([5.0],ei.EI,1)
@@ -32,8 +33,8 @@ class MultiObjExpectedImprovementTests(unittest.TestCase):
         ei.best_cases = bests
         ei.criteria = ['y1','y2','y3']
         ei.predicted_values = [NormalDistribution(mu=1,sigma=1),
-                                                    NormalDistribution(mu=1,sigma=1),
-                                                    NormalDistribution(mu=1,sigma=1)]
+                               NormalDistribution(mu=1,sigma=1),
+                               NormalDistribution(mu=1,sigma=1)]
         ei.execute()
         self.assertAlmostEqual(0.875,ei.PI,1)
 
@@ -46,8 +47,8 @@ class MultiObjExpectedImprovementTests(unittest.TestCase):
         ei.best_cases = bests
         ei.criteria = ['y1','y2','y3']
         ei.predicted_values = [NormalDistribution(mu=1,sigma=1),
-                                                    NormalDistribution(mu=1,sigma=1),
-                                                    NormalDistribution(mu=1,sigma=1)]
+                               NormalDistribution(mu=1,sigma=1),
+                               NormalDistribution(mu=1,sigma=1)]
         ei.calc_switch = 'EI'
         try:
             ei.execute()

--- a/openmdao.main/src/openmdao/main/datatypes/array.py
+++ b/openmdao.main/src/openmdao/main/datatypes/array.py
@@ -130,7 +130,7 @@ class Array(TraitArray):
         info = "an array-like object"
         
         # pylint: disable-msg=E1101
-        if self.shape and value.shape:
+        if self.shape and hasattr(value, 'shape') and value.shape:
             if self.shape != value.shape:
                 info += " of shape %s" % str(self.shape)
                 wtype = "shape"


### PR DESCRIPTION
trait was declared with shape of (2,) which made it illegal to use any different number of predicted values
