### PR TITLE
fixed a test failure on osx 

### DIFF
--- a/openmdao.main/src/openmdao/main/test/test_plugins.py
+++ b/openmdao.main/src/openmdao/main/test/test_plugins.py
@@ -165,9 +165,9 @@ class PluginsTestCase(unittest.TestCase):
             argv = ['docs', 'foobar']
             parser = _get_plugin_parser()
             options, args = parser.parse_known_args(argv)
-            url = _plugin_docs(options.plugin_dist_name)
-            expected = os.path.join(self.tdir, 'foobar', 'src', 'foobar',
-                                    'sphinx_build', 'html', 'index.html')
+            url = os.path.realpath(_plugin_docs(options.plugin_dist_name))
+            expected = os.path.realpath(os.path.join(self.tdir, 'foobar', 'src', 'foobar',
+                                                     'sphinx_build', 'html', 'index.html'))
             self.assertEqual(url, expected)
         finally:
             # Uninstall


### PR DESCRIPTION
it was caused by the fact that on osx, /tmp is actually a symbolic link to /private/tmp
