### PR TITLE
add gui command to cli

### DIFF
--- a/openmdao.gui/src/openmdao/gui/omg.py
+++ b/openmdao.gui/src/openmdao/gui/omg.py
@@ -11,7 +11,7 @@ import os, sys
 import os.path
 import time
 
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 # zmq
 import zmq
@@ -141,45 +141,51 @@ class AppServer(object):
         if not self.options.serveronly:
             launch_browser(self.options.port, self.options.browser)
             
+        DEBUG('Serving on port %d' % self.options.port)
         try:
             ioloop.IOLoop.instance().start()
         except KeyboardInterrupt:
             DEBUG('interrupt received, shutting down.')
 
     @staticmethod
-    def get_options_parser():
+    def get_argument_parser():
         ''' create a parser for command line arguments
         '''
-        parser = OptionParser()
-        parser.add_option("-p", "--port", type="int", dest="port", default=0,
+        parser = ArgumentParser(description = "launch the graphical user interface")
+        parser.add_argument("-p","--port", type=int, dest="port", default=0,
                           help="port to run server on (defaults to any available port)")
-        parser.add_option("-b", "--browser", dest="browser", default="chrome",
+        parser.add_argument("-b","--browser", dest="browser", default="chrome",
                           help="preferred browser")
-        parser.add_option("-s", "--server", action="store_true", dest="serveronly",
+        parser.add_argument("-s","--server", action="store_true", dest="serveronly",
                           help="don't launch browser, just run server")
-        parser.add_option("-r", "--reset", action="store_true", dest="reset",
+        parser.add_argument("-r","--reset", action="store_true", dest="reset",
                           help="reset project database")
-        parser.add_option("-d", "--dev", action="store_true", dest="development",
-                          help="enable development options")
-                          
+        parser.add_argument("-d","--dev", action="store_true", dest="development",
+                          help="enable development options")                          
         return parser
 
-def main():
-    ''' process command line arguments and do as commanded
+def get_argument_parser():
+    ''' shortcut to AppServer argument parser
+    '''
+    return AppServer.get_argument_parser()
+
+def run(parser=None, options=None, args=None):
+    ''' launch the gui with specified options
     '''
     
     # install zmq ioloop before creating any tornado objects
     ioloop.install()
     
     # create the server and kick it off
-    parser = AppServer.get_options_parser()
-    (options, args) = parser.parse_args()
     server = AppServer(options)
-    
-    DEBUG('starting server...')
     server.serve()
+    
+def main():
+    ''' process command line arguments and run
+    '''
+    parser = AppServer.get_argument_parser()
+    options, args = parser.parse_known_args()
+    run(parser, options, args)
         
 if __name__ == '__main__':
-    # dont run main() if this is a forked windows process
-    if sys.modules['__main__'].__file__ == __file__:
-        main()
+    main()

--- a/openmdao.gui/src/openmdao/gui/util.py
+++ b/openmdao.gui/src/openmdao/gui/util.py
@@ -159,6 +159,11 @@ def launch_browser(port,preferred_browser=None):
             CHROMEPATH = '/usr/bin/chromium-browser'
        	    if os.path.isfile(CHROMEPATH):
                 preferred_browser = CHROMEPATH+' --app=%s &'
+    else:
+        print '######################################################################'
+        print ' WARNING: The Chrome browser is currently required!!'
+        print ' You may try another browser but you will not have full functionality'
+        print '######################################################################'
     
     # try to get preferred browser, fall back to default
     if preferred_browser:

--- a/openmdao.main/src/openmdao/main/cli.py
+++ b/openmdao.main/src/openmdao/main/cli.py
@@ -147,7 +147,29 @@ def _get_openmdao_parser():
         
     except ImportError: 
         pass
-    
+
+    # the following subcommands will only be available in a gui build
+    try:
+        import openmdao.gui.omg as gui
+        parser = subparsers.add_parser('gui', help='launch the graphical user interface')
+        # I'd like to do this but argparse doesn't have this signature
+        #parser = subparsers.add_parser('gui', gui.get_argument_parser())
+        # so I'll just copy and paste from openmdao.gui.omg :(
+        parser.add_argument("-p","--port", type=int, dest="port", default=0,
+                          help="port to run server on (defaults to any available port)")
+        parser.add_argument("-b","--browser", dest="browser", default="chrome",
+                          help="preferred browser")
+        parser.add_argument("-s","--server", action="store_true", dest="serveronly",
+                          help="don't launch browser, just run server")
+        parser.add_argument("-r","--reset", action="store_true", dest="reset",
+                          help="reset project database")
+        parser.add_argument("-d","--dev", action="store_true", dest="development",
+                          help="enable development options")
+        parser.set_defaults(func=gui.run)
+
+    except ImportError:
+        pass
+        
     return top_parser
 
 def openmdao():


### PR DESCRIPTION
$ openmdao --help
usage: openmdao [-h]

```
            {list_testhosts,build_docs,test_branch,docs,gui,push_docs,test,test_docs,test_arch}
            ...
```

optional arguments:
  -h, --help            show this help message and exit

commands:
  {list_testhosts,build_docs,test_branch,docs,gui,push_docs,test,test_docs,test_arch}
    list_testhosts      list hosts in testhosts config file
    docs                view the docs
    test_branch         run tests on remote machines
    push_docs           push the dev docs up to the server
    build_docs          build OpenMDAO docs
    test_docs           run tests on the OpenMDAO docs
    test_arch           run the MDAO architecture test suite
    gui                 launch the graphical user interface

$ openmdao gui --help
usage: openmdao gui [-h] [-p PORT] [-b BROWSER] [-s] [-r] [-d]

optional arguments:
  -h, --help            show this help message and exit
  -p PORT, --port PORT  port to run server on (defaults to any available port)
  -b BROWSER, --browser BROWSER
                        preferred browser
  -s, --server          don't launch browser, just run server
  -r, --reset           reset project database
  -d, --dev             enable development options
