### PR TITLE
Testhosts update

### DIFF
--- a/config/testhosts.cfg
+++ b/config/testhosts.cfg
@@ -37,7 +37,7 @@ debug: true
 build_binaries: false
 
 [meerkat32_py26]
-image_id: ami-51c41d38 
+image_id: ami-92ee4bfb 
 instance_type: c1.medium
 user: ubuntu
 platform: linux
@@ -46,7 +46,7 @@ test_branch: true
 test_release: true
 
 [natty32_py27]
-image_id: ami-37ca135e 
+image_id: ami-7cf25715 
 instance_type: c1.medium
 user: ubuntu
 platform: linux
@@ -56,7 +56,7 @@ test_release: true
 pull_docs: true
 
 [meerkat64_py26]
-image_id: ami-d5c41dbc
+image_id: ami-86f356ef
 instance_type: m1.large
 user: ubuntu
 platform: linux
@@ -64,7 +64,7 @@ py: python2.6
 test_release: true
 
 [natty64_py27]
-image_id: ami-bbc41dd2 
+image_id: ami-9cf257f5
 instance_type: m1.large
 user: ubuntu
 platform: linux


### PR DESCRIPTION
Updated the Linux EC2 images to include OS updates and an upgrade from Firefox THREE up to Firefox 12.  The testhosts cfg needed to be updated.
