### PR TITLE
Testhosts update

### DIFF
--- a/config/testhosts.cfg
+++ b/config/testhosts.cfg
@@ -100,7 +100,7 @@ test_branch: false
 test_release: true
 
 [pangolin64_py27]
-image_id: ami-74993d1d 
+image_id: ami-5c339735 
 instance_type: c1.medium
 user: ubuntu
 platform: linux


### PR DESCRIPTION
reimaged pangolin64 to fix the failures that Scott found...updated virtualenv and pip, easy_installed testresources.  this update is just the AMI ID.
