### PR TITLE
Fix for printvars in concurrent mode of caseiterdriver

### DIFF
--- a/openmdao.lib/src/openmdao/lib/drivers/test/test_caseiterdriver.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/test/test_caseiterdriver.py
@@ -65,6 +65,9 @@ class DrivenComponent(Component):
 
     def execute(self):
         """ Compute results from input vector. """
+        
+        self.extra = 2.5
+        
         if self.sleep:
             time.sleep(self.sleep)
         self.rosen_suzuki = rosen_suzuki(self.x)
@@ -120,6 +123,7 @@ class Verifier(Component):
             assert case.msg is None
             assert case['driven.rosen_suzuki'] == rosen_suzuki(case['driven.x'])
             assert case['driven.sum_y'] == sum(case['driven.y'])
+            assert case['driven.extra'] == 2.5
 
 
 class TracedComponent(Component):
@@ -190,6 +194,7 @@ class TestCase(unittest.TestCase):
         self.model.driver.sequential = True
         self.model.driver.iterator = ListCaseIterator(self.cases)
         self.model.driver.recorders = [ListCaseRecorder()]
+        self.model.driver.printvars = ['driven.extra']
         self.model.driver.error_policy = 'RETRY'
         self.model.run()
         
@@ -300,7 +305,7 @@ class TestCase(unittest.TestCase):
                 self.assertEqual(case['driven.sum_y'],
                                  sum(case['driven.y']))
                 self.assertEqual(case['driven.extra'],
-                                 1.5)
+                                 2.5)
 
     def test_save_load(self):
         logging.debug('')
@@ -308,6 +313,7 @@ class TestCase(unittest.TestCase):
 
         self.model.driver.iterator = ListCaseIterator(self.cases)
         results = ListCaseRecorder()
+        self.model.driver.printvars = ['driven.extra']
         self.model.driver.recorders = [results]
 
         # Set local dir in case we're running in a different directory.
@@ -420,6 +426,7 @@ class TestCase(unittest.TestCase):
 
         top.driver.workflow.add(('generator', 'cid', 'verifier'))
         top.cid.workflow.add('driven')
+        top.cid.printvars = ['driven.extra']
 
         top.connect('generator.cases', 'cid.iterator')
         top.connect('cid.evaluated', 'verifier.cases')
@@ -436,6 +443,7 @@ class TestCase(unittest.TestCase):
         rerun_seq = (1, 3, 5, 7, 9)
         self.model.driver.filter = SequenceCaseFilter(rerun_seq)
         rerun = ListCaseRecorder()
+        self.model.driver.printvars = ['driven.extra']
         self.model.driver.recorders[0] = rerun
         self.model.run()
 


### PR DESCRIPTION
From the forums. fzahle found an issue with the concurrent stuff and printvars.
1. The printvars are now added to the case prior to shipping it off to nodes to run.
