### PR TITLE
fixed a bug in find_all_plugins

### DIFF
--- a/openmdao.main/src/openmdao/main/plugin.py
+++ b/openmdao.main/src/openmdao/main/plugin.py
@@ -437,7 +437,7 @@ def _exclude_funct(path):
 #
 # FIXME: this still needs some work, but for testing purposes it's ok for now
 #
-def _find_all_plugins(searchdir):
+def find_all_plugins(searchdir):
     """Return a dict containing lists of each plugin type found, keyed by
     plugin group name, e.g., openmdao.component, openmdao.variable, etc.
     """
@@ -445,13 +445,15 @@ def _find_all_plugins(searchdir):
     psta = PythonSourceTreeAnalyser(searchdir, exclude=_exclude_funct)
     
     for key, lst in plugin_groups.items():
-        dct[key] = set(psta.find_inheritors(lst[0]))
+        epset = set(psta.find_inheritors(lst[0]))
+        if epset:
+            dct[key] = epset 
     return dct
 
 
 def _get_entry_points(startdir):
     """ Return formatted list of entry points. """
-    plugins = _find_all_plugins(startdir)
+    plugins = find_all_plugins(startdir)
     entrypoints = StringIO.StringIO()
     for key,val in plugins.items():
         epts = []

--- a/openmdao.main/src/openmdao/main/test/test_plugins.py
+++ b/openmdao.main/src/openmdao/main/test/test_plugins.py
@@ -10,7 +10,8 @@ from subprocess import check_call, STDOUT
 
 from openmdao.main.plugin import _get_plugin_parser, plugin_quickstart, \
                                  plugin_build_docs, plugin_makedist, \
-                                 plugin_list, _plugin_docs, plugin_install
+                                 plugin_list, _plugin_docs, plugin_install, \
+                                 find_all_plugins
 from openmdao.util.fileutil import find_files
 from openmdao.util.testutil import assert_raises
 
@@ -177,7 +178,7 @@ class PluginsTestCase(unittest.TestCase):
                 out.write('y\n')
             stdin = open('pip.in', 'r')
             stdout = open('pip.out', 'w')
-            # On EC2 Windows, 'pip' genreates an absurdly long temp directory
+            # On EC2 Windows, 'pip' generates an absurdly long temp directory
             # name, apparently to allow backing-out of the uninstall.
             # The name is so long Windows can't handle it. So we try to
             # avoid that by indirectly influencing mkdtemp().
@@ -404,6 +405,29 @@ class PluginsTestCase(unittest.TestCase):
         retval = plugin_install(parser, options, args)
         self.assertEqual(retval, -1)
 
+    def test_find_plugins(self):
+        self.maxDiff = None
+        with open(os.path.join(self.tdir, 'foo.py'), 'w') as f:
+            f.write("""
+from openmdao.main.api import Component, Container
+
+class MyComp(Component):
+    pass
+    
+class MyCont(Container):
+    pass
+            """)
+        expected = {
+            'openmdao.component': set(['foo.MyComp',
+                                       'openmdao.main.component.Component']),
+            'openmdao.container': set(['foo.MyCont',
+                                       'foo.MyComp',
+                                       'openmdao.main.component.Component',
+                                       'openmdao.main.container.Container']),
+        }
+        plugins = find_all_plugins(self.tdir)
+        self.assertEqual(expected.keys(), plugins.keys())
+        self.assertEqual(expected.values(), plugins.values())
 
 if __name__ == '__main__':
     sys.argv.append('--cover-package=openmdao.main')


### PR DESCRIPTION
The bug was causing bogus plugin entry points to be created when running 'plugin makedist'.
