### PR TITLE
Fixed bug from paper

### DIFF
--- a/openmdao.lib/src/openmdao/lib/differentiators/finite_difference.py
+++ b/openmdao.lib/src/openmdao/lib/differentiators/finite_difference.py
@@ -140,6 +140,11 @@ class FiniteDifference(HasTraits):
         """Calculates the gradient vectors for all outputs in this Driver's
         workflow."""
         
+        # Each component runs its calc_derivatives method.
+        # We used to do this in the driver instead, but we've moved it in
+        # here to make the interface more uniform.
+        self._parent.calc_derivatives(first=True)
+        
         self.setup()
 
         # Create our 2D dictionary the first time we execute.
@@ -228,6 +233,11 @@ class FiniteDifference(HasTraits):
             driver needs gradient and hessian information at the same point,
             and calls calc_gradient before calc_hessian.
         """
+        
+        # Each component runs its calc_derivatives method.
+        # We used to do this in the driver instead, but we've moved it in
+        # here to make the interface more uniform.
+        self._parent.calc_derivatives(second=True)
         
         self.setup()
         

--- a/openmdao.lib/src/openmdao/lib/drivers/conmindriver.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/conmindriver.py
@@ -406,7 +406,6 @@ class CONMINdriver(DriverUsesDerivatives):
         # only return gradients of active/violated constraints.
         elif self.cnmn1.info == 2 and self.cnmn1.nfdg == 1:
             
-            self.calc_derivatives(first=True)
             self.ffd_order = 1
             self.differentiator.calc_gradient()
             self.ffd_order = 0

--- a/openmdao.lib/src/openmdao/lib/drivers/newsumtdriver.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/newsumtdriver.py
@@ -160,11 +160,9 @@ def user_function(info, x, obj, dobj, ddobj, g, dg, n2, n3, n4, imode, driver):
         if not driver.differentiator:
             return obj, dobj, ddobj, g, dg
         
-        driver.calc_derivatives(first=True)
         driver.ffd_order = 1
         driver.differentiator.calc_gradient()
         
-        driver.calc_derivatives(second=True)
         driver.ffd_order = 2
         driver.differentiator.calc_hessian(reuse_first=True)
         

--- a/openmdao.lib/src/openmdao/lib/drivers/sensitivity.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/sensitivity.py
@@ -67,9 +67,7 @@ class SensitivityDriver(DriverUsesDerivatives):
         
         self._check()
         
-        
         # Calculate gradient of the workflow
-        self.calc_derivatives(first=True)
         self.ffd_order = 1
         self.differentiator.calc_gradient()
         self.ffd_order = 0

--- a/openmdao.lib/src/openmdao/lib/drivers/slsqpdriver.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/slsqpdriver.py
@@ -210,7 +210,6 @@ class SLSQPdriver(DriverUsesDerivatives):
         
         Note: m, me, la, n, f, g, df, and dg are unused inputs."""
         
-        self.calc_derivatives(first=True)
         self.ffd_order = 1
         self.differentiator.calc_gradient()
         self.ffd_order = 0


### PR DESCRIPTION
While writing the paper on the derivatives stuff, i discovered a small inconsistency between the different differentiators in when I call calc_derivatives. This fixes that inconsistency by moving the call to calc_derivatives out of the driver and into the differentiators. This cleans up the interface on the driver side, to hopefully make it less confusing.
