### PR TITLE
added cleanup back to _test_menu and urls in PluginDocsHandler look for ...

### DIFF
--- a/openmdao.gui/src/openmdao/gui/handlers.py
+++ b/openmdao.gui/src/openmdao/gui/handlers.py
@@ -100,7 +100,7 @@ class PluginDocsHandler(StaticFileHandler):
                 if self._cname_valid(parts[0]) and parts[0] not in self._plugin_map:
                     url = find_docs_url(parts[0], build_if_needed=False)
                     if self.cname.startswith('openmdao.'):
-                        if("egg" in url):
+                        if(url.endswith("egg")):
                             # url points to docs in a release version, so use docs packaged with openmdao.main
                             root = os.path.join(os.path.dirname(openmdao.main.__file__), "docs")
                         else: # url points to docs in a developer version, so use locally built docs

--- a/openmdao.gui/src/openmdao/gui/test/functional/test_workspace.py
+++ b/openmdao.gui/src/openmdao/gui/test/functional/test_workspace.py
@@ -267,6 +267,9 @@ def _test_menu(browser):
         workspace_page('%s_button' % item).click()
         time.sleep(0.5)  # Just so we can see it.
 
+    # Clean up.
+    closeout(projects_page, project_info_page, project_dict, workspace_page)
+
 def _test_macro(browser):
     projects_page, project_info_page, project_dict, workspace_page = startup(browser)
 


### PR DESCRIPTION
Added test cleanup to test_menu. Somehow it got removed. Also made search for "egg" in url more specific by looking for url.endswith("egg").
