### PR TITLE
Docs are installed by default now

### DIFF
--- a/go-openmdao-dev.py
+++ b/go-openmdao-dev.py
@@ -1722,11 +1722,11 @@ def after_install(options, home_dir):
         for req in options.reqs:
             _single_install(cmds, req, bin_dir, failures, dodeps=True)
 
-        activate = os.path.join(home_dir, 'activate')
-        deactivate = os.path.join(home_dir, 'deactivate')
+        activate = os.path.join(bin_dir, 'activate')
+        deactivate = os.path.join(bin_dir, 'deactivate')
         source_command = "." if not sys.platform.startswith("win") else ""
         
-        if(os.system('%s %s && openmdao build_docs && %s' % (source_commad, activate, deactivate)) != 0):
+        if(os.system('%s %s && openmdao build_docs && deactivate' % (source_command, activate)) != 0):
             print "Failed to build the docs."
 
         if sys.platform.startswith('win'): # retrieve MinGW DLLs from server

--- a/openmdao.devtools/src/openmdao/devtools/mkinstaller.py
+++ b/openmdao.devtools/src/openmdao/devtools/mkinstaller.py
@@ -271,11 +271,11 @@ def after_install(options, home_dir):
         for req in options.reqs:
             _single_install(cmds, req, bin_dir, failures, dodeps=True)
 
-        activate = os.path.join(home_dir, 'activate')
-        deactivate = os.path.join(home_dir, 'deactivate')
+        activate = os.path.join(bin_dir, 'activate')
+        deactivate = os.path.join(bin_dir, 'deactivate')
         source_command = "." if not sys.platform.startswith("win") else ""
         
-        if(os.system('%%s %%s && openmdao build_docs && %%s' %% (source_commad, activate, deactivate)) != 0):
+        if(os.system('%%s %%s && openmdao build_docs && deactivate' %% (source_command, activate)) != 0):
             print "Failed to build the docs."
 
         if sys.platform.startswith('win'): # retrieve MinGW DLLs from server


### PR DESCRIPTION
mkinstaller.py and go-openmdao-dev.py have been modified to build the docs by default for a dev build. The reason is because the methods within the GUI assume that the docs have been built.
