### PR TITLE
Set default number of CSV backups to 5

### DIFF
--- a/docs/optimization/case_recorders.rst
+++ b/docs/optimization/case_recorders.rst
@@ -89,6 +89,18 @@ not yet supported by the CSVCaseRecorder, and it is not clear how some of these 
 represented in a comma-separated format. However, the other case recorders should support every type
 of variable, provided that it can be serialized.
 
+The CSVCaseRecorder also saves the csv output files from previous runs. These backup files are given
+unique names that contain the current date and time. The user can specify the number of backups
+to keep for each CSVCaseRecorder object by adding the following line to the above example.
+
+::
+
+   opt_problem.driver.recorders[0].num_backups = 3
+
+If you set the number of backups to 0, no backup files are saved. The default number of backup
+files is 5. Note that it is a rolling save, so the oldest files are deleted as the newest ones 
+are saved so that the total is kept at the desired number.
+
 The DumpCaseRecorder is generally used to write readable text to a
 file or to STDOUT. Let's try using a DumpCaseRecorder to output a history
 of our parameters, constraints, and objectives to a file named ``'data.txt'``.

--- a/openmdao.lib/src/openmdao/lib/casehandlers/csvcase.py
+++ b/openmdao.lib/src/openmdao/lib/casehandlers/csvcase.py
@@ -209,7 +209,7 @@ class CSVCaseRecorder(object):
         self.append = append
         self.outfile = None
         self.csv_writer = None
-        self.num_backups = 0
+        self.num_backups = 5
         self._header_size = 0
         
         #Open output file

--- a/openmdao.lib/src/openmdao/lib/casehandlers/test/test_csvcase.py
+++ b/openmdao.lib/src/openmdao/lib/casehandlers/test/test_csvcase.py
@@ -57,6 +57,7 @@ class CSVCaseRecorderTestCase(unittest.TestCase):
         #being run for the second time.
         
         self.top.driver.recorders = [CSVCaseRecorder(filename=self.filename)]
+        self.top.driver.recorders[0].num_backups = 0
         self.top.run()
         
         # now use the CSV recorder as source of Cases
@@ -97,6 +98,7 @@ class CSVCaseRecorderTestCase(unittest.TestCase):
         
         self.top.driver.recorders = [CSVCaseRecorder(filename=self.filename, delimiter=';', \
                                                      quotechar="'")]
+        self.top.driver.recorders[0].num_backups = 0
         self.top.run()
 
         attrs = self.top.driver.recorders[0].get_attributes()
@@ -276,6 +278,7 @@ class CSVCaseRecorderTestCase(unittest.TestCase):
         self.top.driver.iterator = ListCaseIterator(cases)
             
         self.top.driver.recorders = [CSVCaseRecorder(filename=self.filename)]
+        self.top.driver.recorders[0].num_backups = 0
         self.top.run()
 
         # now use the CSV recorder as source of Cases
@@ -308,6 +311,7 @@ class CSVCaseRecorderTestCase(unittest.TestCase):
         inputs = [('comp1.x_array', array([2.0, 2.0, 2.0]))]
         self.top.driver.iterator = ListCaseIterator([Case(inputs=inputs, outputs=outputs, label='case1')])
         self.top.driver.recorders = [CSVCaseRecorder(filename=self.filename)]
+        self.top.driver.recorders[0].num_backups = 0
         self.top.run()
         
         # now use the CSV recorder as source of Cases
@@ -380,6 +384,7 @@ class CSVCaseRecorderTestCase(unittest.TestCase):
         
     def test_close(self):
         self.top.driver.recorders = [CSVCaseRecorder(filename=self.filename)]
+        self.top.driver.recorders[0].num_backups = 0
         self.top.run()
         case = Case(inputs=[('comp2.a_slot', None)])
         assert_raises(self, 'self.top.driver.recorders[0].record(case)',


### PR DESCRIPTION
Default number of backup files saved by the CSV case recorder is now 5. Also, this feature has been documented in the tutorial.
