### PR TITLE
Fix for auto-complete auto-fill when low or high limits are zero.

### DIFF
--- a/openmdao.gui/src/openmdao/gui/static/js/openmdao/ParametersPane.js
+++ b/openmdao.gui/src/openmdao/gui/static/js/openmdao/ParametersPane.js
@@ -142,10 +142,10 @@ openmdao.ParametersPane = function(elm,model,pathname,name,editable) {
                         
                         lowlimit = null;
                         highlimit = null;
-                        if (input.low) {
+                        if (input.low !== null) {
                             lowlimit = input.low;
                         };
-                        if (input.high) {
+                        if (input.high !== null) {
                             highlimit = input.high;
                         };
                         fullpath = comppath + '.' + input.name
@@ -196,10 +196,10 @@ openmdao.ParametersPane = function(elm,model,pathname,name,editable) {
                         selector.val(ui.item.value);
                         selector.blur();
                         limit = limits[ui.item.value];
-                        if (limit[0]) {
+                        if (limit[0] !== null) {
                             low.val(limit[0]);
                         }
-                        if (limit[1]) {
+                        if (limit[1] !== null) {
                             high.val(limit[1]);
                         }
                     },
@@ -216,10 +216,10 @@ openmdao.ParametersPane = function(elm,model,pathname,name,editable) {
                         // still add the limits from that variable.
                         if (candidates.indexOf(selector.val()) >= 0) {
                             limit = limits[selector.val()];
-                            if (limit[0]) {
+                            if (limit[0] !== null) {
                                 low.val(limit[0]);
                             }
-                            if (limit[1]) {
+                            if (limit[1] !== null) {
                                 high.val(limit[1]);
                             }
                         }

--- a/openmdao.gui/src/openmdao/gui/test/functional/files/connect.py
+++ b/openmdao.gui/src/openmdao/gui/test/functional/files/connect.py
@@ -30,7 +30,7 @@ class Connectable(Component):
 
 class Conn_Bounds(Connectable):
     
-    x = Float(3.3, iotype='in', low=-100, high=299)
+    x = Float(3.3, iotype='in', low=0, high=299)
 
 class Conn_Assy(Assembly):
 

--- a/openmdao.gui/src/openmdao/gui/test/functional/test_workflow.py
+++ b/openmdao.gui/src/openmdao/gui/test/functional/test_workflow.py
@@ -132,7 +132,7 @@ def _test_parameter_auto(browser):
     dialog('ok').click()
     
     parameters = editor.get_parameters()
-    expected = [['', 'comp.x', '-100', '299', '', '', '', 'comp.x']]
+    expected = [['', 'comp.x', '0', '299', '', '', '', 'comp.x']]
     eq(len(parameters.value), len(expected))
     for i, row in enumerate(parameters.value):
         eq(row, expected[i])


### PR DESCRIPTION
Note to self: always check for null value rather than a straight 'if'.

Now when you auto-complete a parameter with 0 as the low or high, the low or high values fill in correctly on the add parameter tab.
