### PR TITLE
For new parameter autocomplete, show inputs in assembly context instead of just the workflow.

### DIFF
--- a/openmdao.gui/src/openmdao/gui/static/js/openmdao/ParametersPane.js
+++ b/openmdao.gui/src/openmdao/gui/static/js/openmdao/ParametersPane.js
@@ -113,7 +113,7 @@ openmdao.ParametersPane = function(elm,model,pathname,name,editable) {
     function promptForParameter(callback, model) {
     
         // Figure out all of our candidates for parameter addition.
-        var parentpath = pathname.split('.').slice(0, -1)[0];
+        var parentpath = pathname.split('.').slice(0, -1).join('.');
         model.getDataflow(parentpath, function findComps(wjson) {
         
             var candidates = [];


### PR DESCRIPTION
A change in the auto-completion candidate list when adding a parameter so that it shows all the available inputs for use as a parameter. This is a much better choice since it save the user a step, and since a component is automatically added to a workflow when one of its inputs is selected as a parameter. 
