### PR TITLE
Fixed some issues with the recorders that were causing exceptions in our tutorials

### DIFF
--- a/openmdao.lib/src/openmdao/lib/casehandlers/csvcase.py
+++ b/openmdao.lib/src/openmdao/lib/casehandlers/csvcase.py
@@ -128,6 +128,12 @@ class CSVCaseIterator(object):
                 
             inputs = []
             for i, field in input_fields.iteritems():
+                
+                # Convert bools from string back into bools
+                # Note, only really need this for inputs.
+                if row[i] in ['True', 'False']:
+                    row[i] = bool(row[i])
+                    
                 inputs.append( (field, row[i]) )
             
             outputs = []
@@ -275,6 +281,19 @@ class CSVCaseRecorder(object):
         input_values = case.values(iotype='in', flatten=True)
         output_keys = case.keys(iotype='out', flatten=True)
         output_values = case.values(iotype='out', flatten=True)
+        
+        # This should not be necessary, however python's csv writer
+        # is not writing boolean variables correctly as strings.
+        
+        for index, item in enumerate(input_values):
+            if isinstance(item, bool):
+                input_values[index] = str(item)
+                
+        for index, item in enumerate(output_values):
+            if isinstance(item, bool):
+                output_values[index] = str(item)
+                
+        # Sort the columns alphabetically.
         
         if len(input_keys) > 0:
             sorted_input_keys, sorted_input_values = \

--- a/openmdao.lib/src/openmdao/lib/casehandlers/test/test_csvcase.py
+++ b/openmdao.lib/src/openmdao/lib/casehandlers/test/test_csvcase.py
@@ -9,7 +9,7 @@ import unittest
 from openmdao.lib.casehandlers.api import CSVCaseIterator, CSVCaseRecorder, \
                                           ListCaseIterator, ListCaseRecorder, \
                                           DumpCaseRecorder
-from openmdao.lib.datatypes.api import Array, Str, Slot
+from openmdao.lib.datatypes.api import Array, Str, Slot, Bool
 from openmdao.lib.drivers.api import SimpleCaseIterDriver, CaseIteratorDriver
 from openmdao.main.api import Component, Assembly, Case, set_as_top
 from openmdao.main.numpy_fallback import array
@@ -29,6 +29,7 @@ class CSVCaseRecorderTestCase(unittest.TestCase):
         top.comp1.add('a_string', Str("Hello',;','", iotype='out'))
         top.comp1.add('a_array', Array(array([1.0, 3.0, 5.5]), iotype='out'))
         top.comp1.add('x_array', Array(array([1.0, 1.0, 1.0]), iotype='in'))
+        top.comp1.add('b_bool', Bool(False, iotype='in'))
         top.comp1.add('vt', Slot(DumbVT, iotype='out'))
         top.comp1.vt = DumbVT()
         driver.workflow.add(['comp1', 'comp2'])
@@ -37,7 +38,8 @@ class CSVCaseRecorderTestCase(unittest.TestCase):
         outputs = ['comp1.z', 'comp2.z', 'comp1.a_string', 'comp1.a_array[2]']
         cases = []
         for i in range(10):
-            inputs = [('comp1.x', i+0.1), ('comp1.y', i*2 + .1), ('comp1.x_array[1]', 99.88)]
+            inputs = [('comp1.x', i+0.1), ('comp1.y', i*2 + .1), 
+                      ('comp1.x_array[1]', 99.88), ('comp1.b_bool', True)]
             cases.append(Case(inputs=inputs, outputs=outputs, label='case%s'%i))
         driver.iterator = ListCaseIterator(cases)
         
@@ -70,6 +72,7 @@ class CSVCaseRecorderTestCase(unittest.TestCase):
             'Case: case8',
             '   uuid: ad4c1b76-64fb-11e0-95a8-001e8cf75fe',
             '   inputs:',
+            '      comp1.b_bool: True',
             '      comp1.x: 8.1',
             '      comp1.x_array[1]: 99.88',
             '      comp1.y: 16.1',
@@ -133,6 +136,7 @@ class CSVCaseRecorderTestCase(unittest.TestCase):
             'Case: case8',
             '   uuid: ad4c1b76-64fb-11e0-95a8-001e8cf75fe',
             '   inputs:',
+            '      comp1.b_bool: True',
             '      comp1.x: 8.1',
             '      comp1.x_array[1]: 99.88',
             '      comp1.y: 16.1',

--- a/openmdao.lib/src/openmdao/lib/casehandlers/test/test_dbcaserecorder.py
+++ b/openmdao.lib/src/openmdao/lib/casehandlers/test/test_dbcaserecorder.py
@@ -19,6 +19,7 @@ from openmdao.lib.casehandlers.api import DBCaseIterator, ListCaseIterator, \
 from openmdao.lib.drivers.api import SimpleCaseIterDriver, DOEdriver, \
                                      CaseIteratorDriver
 from openmdao.main.uncertain_distributions import NormalDistribution
+from openmdao.main.datatypes.api import List, Dict
 from openmdao.util.testutil import assert_raises
 
 from openmdao.main.caseiter import caseiter_to_dict
@@ -30,6 +31,8 @@ class DBCaseRecorderTestCase(unittest.TestCase):
         driver = top.add('driver', SimpleCaseIterDriver())
         top.add('comp1', ExecComp(exprs=['z=x+y']))
         top.add('comp2', ExecComp(exprs=['z=x+1']))
+        top.comp1.add('a_dict', Dict({}, iotype='in'))
+        top.comp1.add('a_list', List([], iotype='in'))
         top.connect('comp1.z', 'comp2.x')
         driver.workflow.add(['comp1', 'comp2'])
         
@@ -37,7 +40,9 @@ class DBCaseRecorderTestCase(unittest.TestCase):
         outputs = ['comp1.z', 'comp2.z']
         cases = []
         for i in range(10):
-            inputs = [('comp1.x', i), ('comp1.y', i*2)]
+            inputs = [('comp1.x', i), ('comp1.y', i*2), 
+                      ('comp1.a_dict', {'a' : 'b'}),
+                      ('comp1.a_list', ['a', 'b'])]
             cases.append(Case(inputs=inputs, outputs=outputs, label='case%s'%i))
         driver.iterator = ListCaseIterator(cases)
 
@@ -73,6 +78,8 @@ class DBCaseRecorderTestCase(unittest.TestCase):
             'Case: case8',
             '   uuid: ad4c1b76-64fb-11e0-95a8-001e8cf75fe',
             '   inputs:',
+            "      comp1.a_dict: {'a': 'b'}",
+            "      comp1.a_list: ['a', 'b']",
             '      comp1.x: 8',
             '      comp1.y: 16',
             '   outputs:',

--- a/openmdao.main/src/openmdao/main/driver_uses_derivatives.py
+++ b/openmdao.main/src/openmdao/main/driver_uses_derivatives.py
@@ -13,7 +13,7 @@ from openmdao.main.driver import Driver
 class DriverUsesDerivatives(Driver): 
     """This class provides an implementation of the derivatives delegates."""
 
-    differentiator = Slot(IDifferentiator, iotype='in',
+    differentiator = Slot(IDifferentiator, 
                           desc = "Slot for a differentiator")
     
     def __init__(self):


### PR DESCRIPTION
This was prompted by problems that Herb found with our Case Recorder and Metamodel tutorials, particularly when setting the printvars to the wildcard *.
1. Added support for boolean variables in the csv writer/reader. Python's csv writer doesn't seem to be properly putting booleans in quotes in the output file, so now we convert them to strings before writing them.
2. It turns out that List and DIct pass around special trait objects that contain a reference to the parent component. This can sometimes cause problems when pickling them for DB insertion, so now we properly cast them as list and dict before pickling.
3. Removed the iotype from the Differentiator slot, because otherwise it ends up in the list of variables that the csv writer tries to output.
