### PR TITLE
Fixed "View Docs" for library items in releases

### DIFF
--- a/openmdao.gui/src/openmdao/gui/handlers.py
+++ b/openmdao.gui/src/openmdao/gui/handlers.py
@@ -3,7 +3,7 @@ from openmdao.gui.session import TornadoSession
 import threading
 import os
 import sys
-
+import re
 import openmdao.main
 from openmdao.main.rbac import Credentials
 from openmdao.main.plugin import find_docs_url
@@ -88,6 +88,7 @@ class PluginDocsHandler(StaticFileHandler):
     ''' retrieve docs for a plugin '''
     _plugin_map = {}
     _plugin_lock = threading.Lock()
+    regex = re.compile("site-packages/openmdao.main-\d+\.\d+\.\d+-py\d\.\d\.egg/openmdao/main")
 
     def _cname_valid(self, name):
         # TODO: use regex to check form of cname (must be dotted module path)
@@ -103,7 +104,7 @@ class PluginDocsHandler(StaticFileHandler):
                 if self._cname_valid(parts[0]) and parts[0] not in self._plugin_map:
                     url = find_docs_url(parts[0], build_if_needed=False)
                     if self.cname.startswith('openmdao.'):
-                        if(url.endswith("egg")):
+                        if(self.regex.search(url)):
                             # url points to docs in a release version, so use docs packaged with openmdao.main
                             root = os.path.join(os.path.dirname(openmdao.main.__file__), "docs")
                         else:  # url points to docs in a developer version, so use locally built docs

--- a/openmdao.gui/src/openmdao/gui/test/functional/pageobjects/workspace.py
+++ b/openmdao.gui/src/openmdao/gui/test/functional/pageobjects/workspace.py
@@ -110,6 +110,9 @@ class WorkspacePage(BasePageObject):
     library_search = InputElement((By.ID, 'objtt-select'))
     library_clear  = ButtonElement((By.ID, 'objtt-clear'))
 
+    library_item_docs = ButtonElement((By.XPATH, "//ul[@id='lib-cmenu']/li[1]"))
+    library_item_metadata = ButtonElement((By.XPATH, "//ul[@id='lib-cmenu']/li[2]"))
+
     # Bottom.
     history = TextElement((By.ID, 'history'))
     command = InputElement((By.ID, 'cmdline'))
@@ -508,6 +511,19 @@ class WorkspacePage(BasePageObject):
             else:
                 break
         return library_item
+
+    def view_library_item_docs(self, item_name):
+        chain = ActionChains(self.browser)
+        current_windows = set(self.browser.window_handles)
+        self.show_library()
+        item = self.get_library_item(item_name)
+        chain.context_click(item).perform()
+        self("library_item_docs").click()
+        new_windows = set(self.browser.window_handles) - current_windows
+        docs_window = list(new_windows)[0]
+
+        return docs_window
+
 
     def add_library_item_to_dataflow(self, item_name, instance_name,
                                      check=True, offset=None, prefix=None,

--- a/openmdao.gui/src/openmdao/gui/test/functional/test_workspace.py
+++ b/openmdao.gui/src/openmdao/gui/test/functional/test_workspace.py
@@ -212,7 +212,7 @@ def _test_loading_docs(browser):
     workspace_page('help_menu').click()
     time.sleep(0.5)
     eq(workspace_page('doc_button').get_attribute('id'), 'help-doc')
-    
+
     workspace_window = browser.current_window_handle
     current_windows = set(browser.window_handles)
     workspace_page('doc_button').click()
@@ -222,11 +222,19 @@ def _test_loading_docs(browser):
     time.sleep(0.5)
     eq("OpenMDAO User Guide" in browser.title, True)
     eq("OpenMDAO Documentation" in browser.title, True)
-   
     browser.close()
     browser.switch_to_window(workspace_window)
+    workspace_page.show_library()
+    browser.switch_to_window(workspace_page.view_library_item_docs("openmdao.main.assembly.Assembly"))
 
-    # Clean up.
+    # Just check to see if a Traceback 404 message was sent.
+    try:
+        browser.find_element((By.XPATH, "/html/head/body/pre[1]"))
+        assert False
+    except:
+        pass
+    browser.close()
+    browser.switch_to_window(workspace_window)
     closeout(project_dict, workspace_page)
 
 def _test_menu(browser):


### PR DESCRIPTION
- Added regex in PluginDocsHandler to detect docs url path for releases
- Added "library_item_docs" attribute to WorkSpacePage
- Added test for viewing the docs of a library item. Fails if the 404 traceback is returned.
