### PR TITLE
Some performance and display fixes for input/output filters in the GUI

### DIFF
--- a/openmdao.gui/src/openmdao/gui/static/js/openmdao/BaseFrame.js
+++ b/openmdao.gui/src/openmdao/gui/static/js/openmdao/BaseFrame.js
@@ -96,12 +96,16 @@ openmdao.BaseFrame.prototype.popup = function (title) {
             panel.height(pane_height);
             panel.width(pane_width);
 
-            // Accomodate any extra stuff after the slickgrid table. This content should
-            // be placed in a div called "post_slick"
+            // Accomodate any extra stuff before or after the slickgrid table.
+            // This content should be placed in a div called "post_slick"
             var extra_height = 0;
             extra = panel.find('.post_slick');
             if (extra.length>0) {
-                extra_height = extra.outerHeight();
+                extra_height += extra.outerHeight();
+            }
+            extra = panel.find('.filterpanel');
+            if (extra.length>0) {
+                extra_height += extra.outerHeight();
             }
 
             // resize all slickgrid viewports and use viewport for scrolling

--- a/openmdao.gui/src/openmdao/gui/static/js/openmdao/PropertiesPane.js
+++ b/openmdao.gui/src/openmdao/gui/static/js/openmdao/PropertiesPane.js
@@ -32,7 +32,7 @@ openmdao.PropertiesPane = function(elm,model,pathname,name,editable,meta) {
     
     if (meta) {
         options.autoHeight = false;
-        elm.append(jQuery("<div id='inlineFilter' style='float:right;padding:10px;'>Filter <input type='text' id='" + name + "_variableFilter' style='width:100px;'></div>"));
+        elm.append(jQuery("<div id='inlineFilter' class='filterpanel' style='float:right;padding:10px;'>Filter <input type='text' id='" + name + "_variableFilter' style='width:100px;'></div>"));
         propsDiv=jQuery("<div id='"+name+"_props' class='slickgrid' style='overflow:none; height:360px; width:620px;'>");
         columns = [
             {id:"name",      name:"Name",        field:"name",      width:100,  formatter:VarTableFormatter },
@@ -91,10 +91,10 @@ openmdao.PropertiesPane = function(elm,model,pathname,name,editable,meta) {
                         _collapsed[items[i].id] = true;
                     }
 
-                    dataView.updateItem(items[i].id, items[i]);
                 }
-                updateFilter({ filter: textboxFilter});
-                
+                dataView.refresh();
+                highlightCells();
+                jQuery(this).trigger('dialogresizestop')
             });
         }
 
@@ -123,9 +123,9 @@ openmdao.PropertiesPane = function(elm,model,pathname,name,editable,meta) {
                         _collapsed[item.id] = false;
                     }
                     // dataView needs to know to update.
-                    dataView.setFilterArgs({filter:expansionFilter});
                     dataView.updateItem(item.id, item);
                     highlightCells();
+                    jQuery("#" + name + "_variableFilter").trigger('dialogresizestop')
                 }
                 e.stopImmediatePropagation();
             }


### PR DESCRIPTION
1. Fixed a performance issue when filtering large input/output tables.
2. Fixed a problem where the editable css state was not correctly applied to the table after filtering.
3. Fixed a problem where the slickgrid div was not sized correctly due to the addition of the filter box.
4. We now explicitly trigger the resizing event whenever we process the filter or expand a variable tree branch in order to correctly account for any newly-appeared horizontal scrollbar.
