### PR TITLE
ExternalCode changes per Chris Heath.

### DIFF
--- a/openmdao.lib/src/openmdao/lib/components/external_code.py
+++ b/openmdao.lib/src/openmdao/lib/components/external_code.py
@@ -82,10 +82,9 @@ class ExternalCode(ComponentWithDerivatives):
         """
         Runs the specified command.
 
-            1. Existing output (but not in/out) files are removed.
-            2. Checks that all external input files exist.
-            3. Runs the command.
-            4. Checks that all external output files exist.
+            1. Checks that all external input files exist.
+            2. Runs the command.
+            3. Checks that all external output files exist.
 
         If a subclass generates outputs (such as postprocessing results),
         then it should set attribute ``check_external_outputs`` False and call
@@ -138,18 +137,6 @@ class ExternalCode(ComponentWithDerivatives):
         """
         self.return_code = -12345678
         self.timed_out = False
-
-        # Remove existing output (but not in/out) files.
-        for metadata in self.external_files:
-            if metadata.get('output', False) and \
-               not metadata.get('input', False):
-                for path in glob.glob(metadata.path):
-                    if os.path.exists(path):
-                        os.remove(path)
-        for pathname, obj in self.items(iotype='out', recurse=True):
-            if isinstance(obj, FileRef):
-                if os.path.exists(obj.path):
-                    os.remove(obj.path)
 
         if not self.command:
             self.raise_exception('Empty command list', ValueError)

--- a/openmdao.lib/src/openmdao/lib/components/test/test_extcode.py
+++ b/openmdao.lib/src/openmdao/lib/components/test/test_extcode.py
@@ -185,18 +185,6 @@ class TestCase(unittest.TestCase):
                       globals(), locals(), RuntimeError,
                       ": missing stdout file 'sleep.out'")
 
-        # Now show that existing outputs are removed before execution.
-        with open('input', 'w') as out:
-            out.write(INP_DATA)
-        sleeper.stdin  = None
-        sleeper.stdout = None
-        sleeper.stderr = None
-        sleeper.env_vars = {}
-        sleeper.env_filename = ''
-        assert_raises(self, 'sleeper.run()',
-                      globals(), locals(), RuntimeError,
-                      ": missing output file 'env-data'")
-
         # Show that non-existent expected files are detected.
         sleeper.external_files.append(
             FileMetadata(path='missing-input', input=True))


### PR DESCRIPTION
Removed the code which removes 'stale' output files.  Causes problems when glob patterns are used in FileMetatdata paths which match unintended local files.
