### PR TITLE
A fix for displaying plugin docs on OS X

### DIFF
--- a/openmdao.main/src/openmdao/main/plugin.py
+++ b/openmdao.main/src/openmdao/main/plugin.py
@@ -628,11 +628,11 @@ def find_docs_url(plugin_name=None, build_if_needed=True):
                 print "local docs not found.\nbuilding them now...\n"
                 check_call(['openmdao', 'build_docs'])
         url += os.path.join(htmldir, anchorpath)
-        url = url.replace('\\', '/')
     else:
         url += os.path.join(os.path.dirname(os.path.abspath(mod.__file__)),
                            'sphinx_build', 'html', 'index.html')
-        url = url.replace('\\', '/')
+        
+    url = url.replace('\\', '/')
     return url
 
 

--- a/openmdao.main/src/openmdao/main/test/test_plugins.py
+++ b/openmdao.main/src/openmdao/main/test/test_plugins.py
@@ -169,6 +169,8 @@ class PluginsTestCase(unittest.TestCase):
             parser = _get_plugin_parser()
             options, args = parser.parse_known_args(argv)
             url = find_docs_url(options.plugin_dist_name)
+            # Strip off the file protocol header
+            url = url.replace('file://', '')
             expected = os.path.join(self.tdir, 'foobar', 'src', 'foobar',
                                     'sphinx_build', 'html', 'index.html')
             self.assertEqual(os.path.realpath(url), os.path.realpath(expected))
@@ -403,6 +405,7 @@ class PluginsTestCase(unittest.TestCase):
         url = find_docs_url(options.plugin_dist_name)
         expected = os.path.join(os.path.dirname(sys.modules['subprocess'].__file__),
                                 'sphinx_build', 'html', 'index.html')
+        expected = 'file://' + expected
         self.assertEqual(url, expected)
 
     def test_install(self):


### PR DESCRIPTION
A fix so that "openmdao docs <plugin name>" will bring up the docs on the Mac. The problem was that "file://" was missing from the url. Most platforms can identify a directory path as a file url, but the Mac doesn't like it.
