### PR TITLE
small fix to the bar3 problem

### DIFF
--- a/examples/openmdao.examples.bar3simulation/openmdao/examples/bar3simulation/bar3_optimization.py
+++ b/examples/openmdao.examples.bar3simulation/openmdao/examples/bar3simulation/bar3_optimization.py
@@ -66,11 +66,11 @@ class Bar3Optimization(Assembly):
        # CONMIN Constraints
 
         constraints = [
-            '(bar3_truss.bar1_stress/bar1_stress_allowable) <= 1.0',
-            '(bar3_truss.bar2_stress/bar2_stress_allowable) <= 1.0',
-            '(bar3_truss.bar3_stress/bar3_stress_allowable) <= 1.0',
-            '(bar3_truss.displacement_x_dir/displacement_x_dir_allowable) <= 1.0',
-            '(bar3_truss.displacement_y_dir/displacement_y_dir_allowable) <= 1.0',
+            'abs(bar3_truss.bar1_stress/bar1_stress_allowable) <= 1.0',
+            'abs(bar3_truss.bar2_stress/bar2_stress_allowable) <= 1.0',
+            'abs(bar3_truss.bar3_stress/bar3_stress_allowable) <= 1.0',
+            'abs(bar3_truss.displacement_x_dir/displacement_x_dir_allowable) <= 1.0',
+            'abs(bar3_truss.displacement_y_dir/displacement_y_dir_allowable) <= 1.0',
             'frequency_allowable**2 <= bar3_truss.frequency**2']
         map(self.driver.add_constraint, constraints)
         

--- a/examples/openmdao.examples.bar3simulation/openmdao/examples/bar3simulation/bar3_wrap_f.py
+++ b/examples/openmdao.examples.bar3simulation/openmdao/examples/bar3simulation/bar3_wrap_f.py
@@ -101,6 +101,12 @@ class Bar3Truss(Component):
         self.bar1_force = float(forces.force1)
         self.bar2_force = float(forces.force2)
         self.bar3_force = float(forces.force3)
+        
+        # The FORTRAN code returns stresses with the wrong sign, so we
+        # flip the sign here (tension = positive).
+        self.bar1_stress = -self.bar1_stress
+        self.bar2_stress = -self.bar2_stress
+        self.bar3_stress = -self.bar3_stress
 
 #end Bar3Truss
     


### PR DESCRIPTION
This fixes a couple of mistakes in the example problem.
1. Stress constraints should be in terms of absolute value (sign means tension/compression).
2. Stresses coming from the Fortran code are the wrong sign, so the sign is corrected in the wrapper.
