### PR TITLE
Changes to the docs from the vartree metamodel changes.

### DIFF
--- a/docs/tutorials/surrogate/mult_outputs.rst
+++ b/docs/tutorials/surrogate/mult_outputs.rst
@@ -53,8 +53,8 @@ is being evaluated for both outputs.
             #Components
             self.add("trig_meta_model",MetaModel())
             self.trig_meta_model.model = Trig()
-            self.trig_meta_model.sur_f_x_sin = LogisticRegression()
-            self.trig_meta_model.sur_f_x_cos = KrigingSurrogate()
+            self.trig_meta_model.surrogates['f_x_sin'] = LogisticRegression()
+            self.trig_meta_model.surrogates['f_x_cos'] = KrigingSurrogate()
             self.trig_meta_model.recorder = DBCaseRecorder()
 
             #Training the MetaModel

--- a/examples/openmdao.examples.metamodel_tutorial/openmdao/examples/metamodel_tutorial/multi_outs.py
+++ b/examples/openmdao.examples.metamodel_tutorial/openmdao/examples/metamodel_tutorial/multi_outs.py
@@ -27,8 +27,8 @@ class Simulation(Assembly):
     
         #Components
         self.add("trig_meta_model",MetaModel())
-        self.trig_meta_model.sur_f_x_sin = LogisticRegression()
-        self.trig_meta_model.sur_f_x_cos = KrigingSurrogate()
+        self.trig_meta_model.surrogates['f_x_sin'] = LogisticRegression()
+        self.trig_meta_model.surrogates['f_x_cos'] = KrigingSurrogate()
         self.trig_meta_model.model = Trig()
         self.trig_meta_model.recorder = DBCaseRecorder()
         

--- a/openmdao.lib/src/openmdao/lib/components/docs/metamodel.rst
+++ b/openmdao.lib/src/openmdao/lib/components/docs/metamodel.rst
@@ -33,15 +33,16 @@ the underlying component.
             self.meta_model.x = 9
             self.meta_model.y = 9
 
-A second slot, called ``default_surrogate`` can be filled with a surrogate model
-generator instance. Copies of this default surrogate model generator will be used for
-any outputs that don't have a specific surrogate model generator associated
-with them. To associate a surrogate model generator with a specific output,
-you must first fill the `model` slot so that MetaModel can determine what your
-outputs are. When `model` is filled, MetaModel will create a slot named
-``sur_<output_name>`` for each output of the model. To override the default
-surrogate model generator for a specific output, just drop the new surrogate
-model generator into the ``sur_<output_name>`` slot. All surrogate model
+A second slot, called ``default_surrogate`` can be filled with a surrogate
+model generator instance. Copies of this default surrogate model generator
+will be used for any outputs that don't have a specific surrogate model
+generator associated with them. To associate a surrogate model generator with
+a specific output, you must first fill the `model` slot so that MetaModel can
+determine what your outputs are. When `model` is filled, MetaModel will
+create a dictionary named surrogates where the keys are the variable names in
+the model, and the values are slots. To override the default surrogate model
+generator for a specific output, just drop the new surrogate model generator
+into the slot whose key is the output of interest. All surrogate model
 generators must implement the ISurrogate interface. OpenMDAO provides some
 surrogate model generators in the ``openmdao.lib.surrogatemodels`` directory.
 
@@ -60,12 +61,15 @@ surrogate model generators in the ``openmdao.lib.surrogatemodels`` directory.
             #component has two inputs: x,y
             self.meta_model.model = BraninComponent()
 
-            #once the 'model' slot has been filled, a slot named 'sur_<name>' will
-            #be created for each output variable. In this case we'll just put
+            #once the 'model' slot has been filled, a dictionary named 'surrogates' will
+            #be created. The dictionary's keys are the variable names, and the values are
+            #slots where a surrogate model instance can be filled. In this case we'll just put
             #another KrigingSurrogate in there, just to show how it's done. Since
             #the default_surrogate is also a KrigingSurrogate, this will give us
             #the same results we would have had if we'd only used the default_surrogate.
-            self.sur_f_xy = KrigingSurrogate() # use Kriging for the f_xy output
+            
+            # use Kriging for the f_xy output
+            self.meta_model.surrogates['f_xy'] = KrigingSurrogate() 
             
             #meta_model now has two inputs: x,y
             self.meta_model.x = 9


### PR DESCRIPTION
Changes to the docs because the surrogate slots are now in a dictionary.
