### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ build.out
 
 # OS generated files #
 ######################
-.DS_Store?
+.DS_Store
 ehthumbs.db
 Thumbs.db
 


### PR DESCRIPTION
I noticed that .DS_Store files generated by OSX were not actually being hidden on my machine. This commit fixes that for me (OSX Lion 10.7)
