### PR TITLE
Scrolling to Zoom

### DIFF
--- a/openmdao.gui/src/openmdao/gui/static/js/WebViewer/simpleUI.js
+++ b/openmdao.gui/src/openmdao/gui/static/js/WebViewer/simpleUI.js
@@ -213,7 +213,6 @@ function wvUpdateUI()
 
   if (g.wheelDelta !== 0)
   {
-    
     var scale = Math.exp(g.wheelDelta/128.0);
     g.mvMatrix.scale(scale, scale, scale);
     g.scale   *= scale;


### PR DESCRIPTION
User can use scrolling to zoom in/out in the geometry viewer.

With mouse: Use the mouse wheel
Mac trackpad: Use two finger scrolling
