### PR TITLE
added some time.sleep to allow for certain GUI actions to complete. test...

### DIFF
--- a/openmdao.gui/src/openmdao/gui/test/functional/test_workspace.py
+++ b/openmdao.gui/src/openmdao/gui/test/functional/test_workspace.py
@@ -1059,8 +1059,11 @@ def _test_removefiles(browser):
 
     # Test deleting a file in a folder
     workspace_page.new_folder( "test_folder" )
+    time.sleep(1.0)
     workspace_page.add_file_to_folder( "test_folder", paraboloidPath )
+    time.sleep(1.0)
     workspace_page.expand_folder( 'test_folder' )
+    time.sleep(1.0)
     workspace_page.delete_files( [ 'test_folder/paraboloid.py', ] )
 
     # Check to make sure the file was deleted


### PR DESCRIPTION
..._removefiles was failing on Windows. Not sure why only Windows but it might be more because it was on EC2
