### PR TITLE
Bug fix in csvcase.py

### DIFF
--- a/openmdao.lib/src/openmdao/lib/casehandlers/csvcase.py
+++ b/openmdao.lib/src/openmdao/lib/casehandlers/csvcase.py
@@ -144,6 +144,8 @@ class CSVCaseIterator(object):
                        retries=retries, max_retries=max_retries, \
                        parent_uuid=parent_uuid, msg=msg)
 
+        self.need_fieldnames = True
+
     def _parse_fieldnames(self, row):
         ''' Parse our input and output fieldname dictionaries
         '''

--- a/openmdao.lib/src/openmdao/lib/casehandlers/test/test_csvcase.py
+++ b/openmdao.lib/src/openmdao/lib/casehandlers/test/test_csvcase.py
@@ -443,5 +443,20 @@ class CSVCaseRecorderTestCase(unittest.TestCase):
         
         self.top.driver.recorders[0].num_backups = 0
 
+    def test_iterate_twice(self):
+
+        self.top.driver.recorders = [CSVCaseRecorder(filename=self.filename)]
+        self.top.run()
+        
+        data = self.top.driver.recorders[0].get_iterator()
+        
+        for case in data:
+            keys1 = case.keys()
+        
+        for case in data:
+            keys2 = case.keys()
+        
+        self.assertEqual(keys1, keys2)
+        
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When a CSVCaseRecorder object is iterated twice, a dictionary keyword error is raised in the second time because the object has an empty data. The empty data is due to member variable 'self.need_fieldnames' being False once the object is iterated once.
