### PR TITLE
last_saved_metadata no longer calls logout.

### DIFF
--- a/openmdao.gui/src/openmdao/gui/test/functional/test_project.py
+++ b/openmdao.gui/src/openmdao/gui/test/functional/test_project.py
@@ -137,8 +137,7 @@ def _test_last_saved_metadata(browser):
     projects_page, project_name, commit_project_time = commit_project(projects_page, project_name, replace_object_time)
     projects_page, project_name, revert_project_time = revert_project(projects_page, project_name, commit_project_time)
 
-    projects_page.logout()
-
+    projects_page.delete_project(project_name)
     
 #Test creating a project
 def _test_new_project(browser):


### PR DESCRIPTION
Fixed an error related to running tests in test_project outside of the test suite (python test_project.py --nonose). Both tests (last_saved_metadata, new_project) work now. 
