### PR TITLE
Fixed autocomplete when adding parameters

### DIFF
--- a/openmdao.gui/src/openmdao/gui/static/js/openmdao/ParametersPane.js
+++ b/openmdao.gui/src/openmdao/gui/static/js/openmdao/ParametersPane.js
@@ -132,6 +132,11 @@ openmdao.ParametersPane = function(elm, project, pathname, name, editable) {
                         return;
                     }
 
+                    //Do not include vartree roots
+                    if(input.hasOwnProperty('vt')){
+                        return;
+                    }
+
                     lowlimit = null;
                     highlimit = null;
                     if (input.low !== null) {
@@ -140,7 +145,15 @@ openmdao.ParametersPane = function(elm, project, pathname, name, editable) {
                     if (input.high !== null) {
                         highlimit = input.high;
                     }
-                    fullpath = comppath + '.' + input.name;
+
+                    if(input.hasOwnProperty("parent")){
+                        fullpath = comppath + '.' + input.id;
+                    }
+                    
+                    else{
+                        fullpath = comppath + '.' + input.name;
+                    }
+
                     candidates.push(fullpath);
                     limits[fullpath] = [lowlimit, highlimit];
                 });

--- a/openmdao.gui/src/openmdao/gui/test/functional/pageobjects/component.py
+++ b/openmdao.gui/src/openmdao/gui/test/functional/pageobjects/component.py
@@ -310,6 +310,11 @@ class ParameterDialog(DialogPage):
     ok     = ButtonElement((By.ID, 'parameter-ok'))
     cancel = ButtonElement((By.ID, 'parameter-cancel'))
 
+    def get_autocomplete_targets(self, target):
+        self.target = target
+        return self.browser.find_elements_by_xpath("//ul[contains(@class, 'ui-autocomplete')]/li")
+
+
 
 class ObjectiveDialog(DialogPage):
     """ Dialog for adding a new objective. """

--- a/openmdao.gui/src/openmdao/gui/test/functional/test_dataflow.py
+++ b/openmdao.gui/src/openmdao/gui/test/functional/test_dataflow.py
@@ -655,6 +655,50 @@ def _test_ordering(browser):
     editor.close()
     closeout(project_dict, workspace_page)
 
+def _test_parameter_autocomplete(browser):
+    project_dict, workspace_page = startup(browser)
+    file_path = pkg_resources.resource_filename('openmdao.gui.test.functional',
+                                                'files/model_vartree.py')
+    workspace_page.add_file(file_path)
+    workspace_page.add_library_item_to_dataflow('model_vartree.Topp', "vartree", prefix=None)
+    workspace_page.replace_driver('vartree', 'SLSQPdriver')
+
+    driver = workspace_page.get_dataflow_figure('driver', 'vartree')
+    editor = driver.editor_page(base_type='Driver')
+    editor('parameters_tab').click()
+    dialog = editor.new_parameter()
+
+    expected_targets = set([
+        'p1.cont_in.v1',
+        'p1.cont_in.v2',
+        'p1.cont_in.vt2.x',
+        'p1.cont_in.vt2.y',
+        'p1.cont_in.vt2.vt3.a',
+        'p1.cont_in.vt2.vt3.b',
+        'p1.directory',
+        'p1.force_execute',
+        ])
+    
+    autocomplete_targets = [element.text for element in dialog.get_autocomplete_targets('p1')]
+
+    #For p1 (simplecomp) there should only be
+    #8 valid autocomplete targets.
+
+    eq(len(autocomplete_targets), 8)
+
+    for target in autocomplete_targets:
+        eq(target in expected_targets, True)
+
+    #The autocomplete menu blocks the cancel button.
+    #Enter a value in low is to remove the focus from the target cell
+    #to get rid of the autocomplete menu.
+    dialog.low = '0'
+
+    dialog('cancel').click()
+
+    editor.close()
+    closeout(project_dict, workspace_page)
+    
 
 def _test_io_filter_without_vartree(browser):
 


### PR DESCRIPTION
Fixed the variable paths displayed for vartree variables in the drop down selection when adding parameters.
