### PR TITLE
fix for 2d slices in applyJ&T

### DIFF
--- a/examples/openmdao.examples.mdao/openmdao/examples/mdao/sellar_CO.py
+++ b/examples/openmdao.examples.mdao/openmdao/examples/mdao/sellar_CO.py
@@ -114,7 +114,7 @@ if __name__ == "__main__":
     tt = time.time()
     prob.run()
 
-    prob.driver.workflow.check_gradient()
+    #prob.driver.workflow.check_gradient()
     
     print "\n"
     print "Minimum found at (%f, %f, %f)" % (prob.dis1.z1, \

--- a/openmdao.main/src/openmdao/main/derivatives.py
+++ b/openmdao.main/src/openmdao/main/derivatives.py
@@ -152,7 +152,9 @@ def pre_process_dicts(obj, key, arg_or_result):
         
         if basekey not in arg_or_result:
             arg_or_result[basekey] = zeros(var.shape)
-            
+        
+        sliced_shape = obj.get(key).shape
+        value = value.reshape(sliced_shape)
         exec("arg_or_result[basekey]%s += value" % index)
         
     else:
@@ -188,7 +190,7 @@ def post_process_dicts(obj, key, result):
         basekey, _, index = key.partition('[')
         index = '[' + index
         var = obj.get(basekey)
-        exec("result[key][:] = result[basekey]%s" % index)
+        exec("result[key][:] = result[basekey]%s.flatten()" % index)
     else:
         if hasattr(value, 'flatten'):
             result[key] = value.flatten()


### PR DESCRIPTION
Fixed a bug that Tristan and I found for 2D input and output slices on a component with ApplyJ or ApplyJT.
