### PR TITLE
Fixing pangolin instance that was leaving its EBS volumes around after t...

### DIFF
--- a/config/testhosts.cfg
+++ b/config/testhosts.cfg
@@ -64,7 +64,7 @@ test_branch: true
 test_release: true
 
 [pangolin64_py27]
-image_id: ami-ec720b85
+image_id: ami-53132c3a
 instance_type: c1.medium
 user: ubuntu
 platform: linux


### PR DESCRIPTION
...ermination.

This left over 200 EBS block volumes sitting around uncleaned.
