### PR TITLE
Reset pseudocomp count in solver tests to stop intermittent test failure

### DIFF
--- a/openmdao.lib/src/openmdao/lib/drivers/test/test_broydensolver.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/test/test_broydensolver.py
@@ -12,6 +12,7 @@ from openmdao.util.decorators import add_delegate
 from openmdao.lib.drivers.api import BroydenSolver
 from openmdao.main.datatypes.api import Array, Float
 from openmdao.util.testutil import assert_rel_error, assert_raises
+import openmdao.main.pseudocomp as pcompmod
 
 # pylint: disable-msg=E1101,E1103
 # "Instance of <class> has no <attr> member"
@@ -184,12 +185,12 @@ class TestCase(unittest.TestCase):
     def setUp(self):
         """ Called before each test. """
         self.prob = None
-        pass
+        pcompmod._count = 0 # keep pseudocomp names consistent for each test
+                            # to avoid weird stuff like hash order changes
 
     def tearDown(self):
         """ Called after each test. """
         self.prob = None
-        pass
 
     def test_Broyden2(self):
 

--- a/openmdao.lib/src/openmdao/lib/drivers/test/test_iterate.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/test/test_iterate.py
@@ -12,7 +12,7 @@ from openmdao.lib.optproblems.sellar import Discipline1_WithDerivatives, \
 from openmdao.main.api import Assembly, Component, set_as_top
 from openmdao.main.datatypes.api import Array, Float
 from openmdao.util.testutil import assert_rel_error
-
+import openmdao.main.pseudocomp as pcompmod
 
 class Simple1(Component):
     """ Testing convergence failure"""
@@ -90,6 +90,8 @@ class FixedPointIteratorTestCase(unittest.TestCase):
 
     def setUp(self):
         self.top = set_as_top(Assembly())
+        pcompmod._count = 0 # keep pseudocomp names consistent for each test
+                            # to avoid weird stuff like hash order changes
 
     def tearDown(self):
         self.top = None

--- a/openmdao.lib/src/openmdao/lib/drivers/test/test_newton.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/test/test_newton.py
@@ -20,6 +20,7 @@ from openmdao.lib.drivers.api import BroydenSolver
 from openmdao.main.datatypes.api import Float
 from openmdao.test.execcomp import ExecComp
 from openmdao.util.testutil import assert_rel_error
+import openmdao.main.pseudocomp as pcompmod
 
 
 class Sellar_MDA(Assembly):
@@ -162,6 +163,8 @@ class MDA_SolverTestCase(unittest.TestCase):
 
     def setUp(self):
         self.top = set_as_top(Sellar_MDA())
+        pcompmod._count = 0 # keep pseudocomp names consistent for each test
+                            # to avoid weird stuff like hash order changes
 
     def tearDown(self):
         self.top = None


### PR DESCRIPTION
Note: I haven't seen this fail in a while, but put the fix in anyway.
