### PR TITLE
Fix for problem with fd_step in parameters when pseudocomps are in the parameter_group

### DIFF
--- a/openmdao.main/src/openmdao/main/derivatives.py
+++ b/openmdao.main/src/openmdao/main/derivatives.py
@@ -655,9 +655,10 @@ class FiniteDifference(object):
             if 'high' in meta:
                 high = meta[ 'high' ]
 
-            if srcs[0] in driver_targets:
-                if srcs[0] in driver_params:
-                    param = driver_params[srcs[0]]
+            param_srcs = [item for item in srcs if item in driver_targets]
+            if param_srcs:
+                if param_srcs[0] in driver_params:
+                    param = driver_params[param_srcs[0]]
                     if param.fd_step is not None:
                         self.fd_step[j] = param.fd_step
                     if param.low is not None:
@@ -669,7 +670,7 @@ class FiniteDifference(object):
                     for param_group in driver_params:
                         is_fd_step_not_set = is_low_not_set = is_high_not_set = True
                         if not isinstance(param_group, str) and \
-                           srcs[0] in param_group:
+                           param_srcs[0] in param_group:
                             param = driver_params[param_group]
                             if is_fd_step_not_set and param.fd_step is not None:
                                 self.fd_step[j] = param.fd_step

--- a/openmdao.main/src/openmdao/main/test/test_derivatives_fd.py
+++ b/openmdao.main/src/openmdao/main/test/test_derivatives_fd.py
@@ -26,7 +26,7 @@ class MyComp(Component):
     #     gradient_options.fd_step_type to 'bounds_scaled'
     x6 = Float(1.0, iotype='in', fd_step = 0.001,
                low=0.0, high=100.0
-               ) 
+               )
     # So we can test the check on needing low and high when using bounds_scaled
     x7 = Float(1.0, iotype='in', fd_step = 0.01,
                fd_step_type='bounds_scaled')
@@ -100,6 +100,16 @@ class TestFiniteDifference(unittest.TestCase):
 
         assert_rel_error(self, J[0, 1], 8.004, 0.0001)
 
+        # More Parameter Groups with pseudocomps in them.
+        model.driver.add_parameter('comp.x4', low=-100, high=100, fd_step=1.001)
+        model.driver.add_objective('comp.x1 + comp.x2 + comp.x3 + comp.x4 + comp.y')
+
+
+        model.run()
+        model.driver.workflow.config_changed()
+        J = model.driver.workflow.calc_gradient(inputs=['comp.x4'], mode='fd')
+        assert_rel_error(self, J[0, 0], 1.006, 0.0001)
+
 
     def test_central(self):
 
@@ -169,7 +179,7 @@ class TestFiniteDifference(unittest.TestCase):
                "For variable 'comp.x7', a finite "
                "difference step type of bounds_scaled "
                "is used but required low and high "
-               "values are not set" ) 
+               "values are not set" )
         else:
             self.fail("Exception expected because low "
                       "and high not set for comp.x7")


### PR DESCRIPTION
1. FIx for a forum-reported problem in which the fd_step from a parameter wasn't correctly pulled from it because of a hole in the logic.
