### PR TITLE
Testhosts

### DIFF
--- a/config/testhosts.cfg
+++ b/config/testhosts.cfg
@@ -97,7 +97,7 @@ build_binaries: true
 
 [win2008_32_py27_no_compilers]
 image_id: ami-77c6d81e 
-instance_type: m3.medium
+instance_type: c1.medium
 user: Administrator
 security_groups: windows
 platform: windows


### PR DESCRIPTION
updating testhosts file to reflect retirement of quetzal, addition of trusty tahr, and changeover of EC2 instance types for 64-bit machines from c1.medium to m3.medium.
