### PR TITLE
Turning off banner in Chrome

### DIFF
--- a/openmdao.gui/src/openmdao/gui/test/functional/util.py
+++ b/openmdao.gui/src/openmdao/gui/test/functional/util.py
@@ -121,11 +121,16 @@ def setup_chrome():
             os.remove(filename)
         finally:
             os.chdir(orig_dir)
+    """
+    Adding code here to eliminate warning banner in Chrome (as of
+    version 35)  The banner pushes the display downward and makes some 
+    items unclickable in Selenium.  Adding the test-type flag turns off the banner 
+    """
     from selenium.webdriver.chrome.options import Options
     chrome_options = Options()
     chrome_options.add_argument("--test-type")
     driver = webdriver.Chrome(executable_path=path, chrome_options=chrome_options)
-    #driver = webdriver.Chrome(executable_path=path)
+
     driver.implicitly_wait(15)
     TEST_CONFIG['browsers'].append(driver)
     return driver


### PR DESCRIPTION
Banner that appears as of version 35 of chrome "--ignore-certificate-warning" is squashing screen downward and making us sometimes miss click events.  This adds an argument that turns off the warning banner and should cut down on missed click events.
