### PR TITLE
fixing error in instance type for no_compilers instance

### DIFF
--- a/config/testhosts.cfg
+++ b/config/testhosts.cfg
@@ -97,7 +97,7 @@ build_binaries: true
 
 [win2008_32_py27_no_compilers]
 image_id: ami-77c6d81e 
-instance_type: m3.medium
+instance_type: c1.medium
 user: Administrator
 security_groups: windows
 platform: windows


### PR DESCRIPTION
wrong type of instance added for 32-bit machine, no_compilers instance wouldn't launch until it was changed.
