### PR TITLE
Made connection expression error message for undefined variables more specific

### DIFF
--- a/openmdao.main/src/openmdao/main/exprmapper.py
+++ b/openmdao.main/src/openmdao/main/exprmapper.py
@@ -229,14 +229,14 @@ class ExprMapper(object):
             invalid_vars = srcexpr.get_unresolved() + destexpr.get_unresolved()
             parts = invalid_vars[0].rsplit('.', 1)
 
-            parent = scope.name
-            vname = parts[0]
+            parent = repr(scope.name) if scope.name else 'top level assembly'
+            vname = repr(parts[0])
 
             if len(parts) > 1:
-                parent = parts[0]
-                vname = parts[1]
+                parent = repr(parts[0])
+                vname = repr(parts[1])
 
-            msg = "'{parent}' has no variable '{vname}'"
+            msg = "{parent} has no variable {vname}"
             msg = msg.format(parent=parent, vname=vname)
 
             raise AttributeError, AttributeError(msg), traceback

--- a/openmdao.main/src/openmdao/main/test/test_assembly.py
+++ b/openmdao.main/src/openmdao/main/test/test_assembly.py
@@ -420,17 +420,6 @@ class AssemblyTestCase(unittest.TestCase):
         else:
             self.fail('exception expected')
 
-    def test_metadata_link(self):
-        try:
-            self.asm.connect('comp1.rout.units', 'comp2.s')
-        except Exception, err:
-            self.assertEqual(str(err),
-                             ": Can't connect 'comp1.rout.units' to 'comp2.s':"
-                             " Couldn't find metadata for traits"
-                             " 'comp1.rout.units'")
-        else:
-            self.fail('Exception expected')
-
     def test_get_metadata(self):
         units = self.asm.comp1.get_metadata('rout', 'units')
         self.assertEqual(units, 'ft')

--- a/openmdao.main/src/openmdao/main/test/test_connect_var.py
+++ b/openmdao.main/src/openmdao/main/test/test_connect_var.py
@@ -83,6 +83,28 @@ class VariableTestCase(unittest.TestCase):
 
             self.assertEqual(str(err), expected)
 
+        try:
+            self.top.add('a', Assembly())
+            self.top.a.add('oneinp', Oneinp())
+            self.top.a.connect('fake', 'oneinp.ratio1')
+        except AttributeError as err:
+            expected = "a: "\
+                       "Can't connect 'fake' to 'oneinp.ratio1': "\
+                       "'a' has no variable 'fake'"
+
+            self.assertEqual(str(err), expected)
+
+        try:
+            self.top.connect('fake', 'oneinp.ratio1')
+        except AttributeError as err:
+            expected = ": "\
+                       "Can't connect 'fake' to 'oneinp.ratio1': "\
+                       "top level assembly has no variable 'fake'"
+
+            self.assertEqual(str(err), expected)
+
+
+
     def test_undefined_destexpr_var(self):
         try:
             self.top.connect('oneout.ratio1', 'oneinp.fake')
@@ -90,6 +112,26 @@ class VariableTestCase(unittest.TestCase):
             expected = ": "\
                        "Can't connect 'oneout.ratio1' to 'oneinp.fake': "\
                        "'oneinp' has no variable 'fake'"
+
+            self.assertEqual(str(err), expected)
+
+        try:
+            self.top.connect('oneout.ratio1', 'fake')
+        except AttributeError as err:
+            expected = ": "\
+                       "Can't connect 'oneout.ratio1' to 'fake': "\
+                       "top level assembly has no variable 'fake'"
+
+            self.assertEqual(str(err), expected)
+
+        try:
+            self.top.add('a', Assembly())
+            self.top.a.add('oneout', Oneout())
+            self.top.a.connect('oneout.ratio1', 'fake')
+        except AttributeError as err:
+            expected = "a: "\
+                       "Can't connect 'oneout.ratio1' to 'fake': "\
+                       "'a' has no variable 'fake'"
 
             self.assertEqual(str(err), expected)
 


### PR DESCRIPTION
- Connection expression error message for undefined variables states first variable in expression that is undefined.
- Removed `parent` argument from  `_needs_pseduo_comp` because argument was not used within function
