### PR TITLE
fixed exception in add_coupling_var

### DIFF
--- a/openmdao.main/src/openmdao/main/problem_formulation.py
+++ b/openmdao.main/src/openmdao/main/problem_formulation.py
@@ -97,16 +97,10 @@ class HasCouplingVars(object):
                                          "'%s' because it is not a valid "
                                          "variable." % dep, ValueError)
         if self._couples:
-            if indep in [c[0] for c in self._couples]:
-                self._parent.raise_exception("Coupling variable with indep '%s'"
-                                             " already exists in assembly."
-                                             % indep, ValueError)
-
-            #It should be allowed for dependents to repeat
-            #if dep in [c[1] for c in self._couples]:
-            #   self._parent.raise_exception("Coupling variable with dep '%s'"
-            #                                " already exists in assembly"
-            #                                % dep, ValueError)
+            if dep in [c[1] for c in self._couples]:
+               self._parent.raise_exception("Coupling variable with dep '%s'"
+                                            " already exists in assembly"
+                                            % dep, ValueError)
 
         if name is None:
             name = indep_dep


### PR DESCRIPTION
Changed the check in problem_formulation.add_coupling_var() to allow for multiple couples with the same independent variable but only one to use one dependent variable.
