### PR TITLE
Mpi Improvements

### DIFF
--- a/contrib/testmpi/test_mpi.py
+++ b/contrib/testmpi/test_mpi.py
@@ -13,6 +13,7 @@ from openmdao.main.interfaces import implements, ISolver
 from openmdao.main.datatypes.api import Float, Array
 from openmdao.main.mpiwrap import MPI
 from openmdao.lib.drivers.iterate import FixedPointIterator
+from openmdao.lib.drivers.newton_solver import NewtonSolver
 from openmdao.test.execcomp import ExecComp
 from openmdao.main.test.test_derivatives import SimpleDriver
 
@@ -70,6 +71,36 @@ class SellarMDF(Assembly):
         # Inner Loop - Full Multidisciplinary Solve via fixed point iteration
         C1 = self.add('C1', sellar.Discipline1())
         C2 = self.add('C2', sellar.Discipline2())
+
+        self.driver.workflow.add(['C1','C2'])
+
+        #not relevant to the iteration. Just fixed constants
+        C1.z1 = C2.z1 = 1.9776
+        C1.z2 = C2.z2 = 0
+        C1.x1 = 0
+
+        # Solver settings
+        self.driver.max_iteration = 5
+        self.driver.tolerance = 1.e-15
+        self.driver.print_convergence = False
+
+class SellarMDFwithDerivs(Assembly):
+    """ Optimization of the Sellar problem using MDF
+    Disciplines coupled with FixedPointIterator.
+    """
+    def configure(self):
+        """ Creates a new Assembly with this problem
+
+        Optimal Design at (1.9776, 0, 0)
+
+        Optimal Objective = 3.18339
+        """
+
+        self.add('driver', FixedPointIterator())
+
+        # Inner Loop - Full Multidisciplinary Solve via fixed point iteration
+        C1 = self.add('C1', sellar.Discipline1_WithDerivatives())
+        C2 = self.add('C2', sellar.Discipline2_WithDerivatives())
 
         self.driver.workflow.add(['C1','C2'])
 
@@ -395,6 +426,38 @@ class MPITests2(MPITestCase):
         expected = { 'C1.y1': 3.1598617768014536, 'C2.y2': 3.7551999159927316 }
 
         top.run()
+        
+        # gather the values back to the rank 0 process and compare to expected
+        dist_answers = top._system.mpi.comm.gather([(k[0],v) for k,v in top._system.vec['u'].items()], 
+                                                   root=0)
+        if self.comm.rank == 0:
+            for answers in dist_answers:
+                for name, val in answers:
+                    if name in expected:
+                        #print self.comm.rank, name, val[0]
+                        assert_rel_error(self, val[0], expected[name], 0.001)
+                        del expected[name]
+
+            if expected:
+                self.fail("not all expected values were found")
+
+    def test_sellar_Newton_parallel(self):
+
+        top = set_as_top(SellarMDFwithDerivs())
+        top.replace('driver', NewtonSolver())
+
+        top.driver.add_parameter('C2.y1', low=-1e99, high=1e99)
+        top.driver.add_constraint('C1.y1 = C2.y1')
+        top.driver.add_parameter('C1.y2', low=-1.e99, high=1.e99)
+        top.driver.add_constraint('C2.y2 = C1.y2')
+
+        expected = { 'C1.y1': 3.1598617768014536, 'C2.y2': 3.7551999159927316 }
+
+        top.driver.iprint = 1
+        top.driver.max_iteration = 20
+        top.run()
+        print top.C1.y1, top.C2.y1
+        print top.C1.y2, top.C2.y2
         
         # gather the values back to the rank 0 process and compare to expected
         dist_answers = top._system.mpi.comm.gather([(k[0],v) for k,v in top._system.vec['u'].items()], 

--- a/contrib/testmpi/test_mpi.py
+++ b/contrib/testmpi/test_mpi.py
@@ -331,15 +331,15 @@ class MPITests1(MPITestCase):
             def execute(self):
                # Direct uvec setting
                 uvec = self._system.vec['u']
-                print uvec.keys()
+                #print uvec.keys()
                 # Only can interact with the var that is in our node
                 for num in [1.0, 2.0, 3.0]:
                     if 'comp1.x' in uvec:
                         uvec['comp1.x'] = num
-                        print "SETTING", 'comp1.x', uvec['comp1.x']
+                        #print "SETTING", 'comp1.x', uvec['comp1.x']
                     if 'comp2.x' in uvec:
                         uvec['comp2.x'] = num
-                        print "SETTING", 'comp2.x', uvec['comp2.x']
+                        #print "SETTING", 'comp2.x', uvec['comp2.x']
                         
                     self.run_iteration()
 
@@ -403,7 +403,7 @@ class MPITests2(MPITestCase):
             for answers in dist_answers:
                 for name, val in answers:
                     if name in expected:
-                        print self.comm.rank, name, val[0]
+                        #print self.comm.rank, name, val[0]
                         assert_rel_error(self, val[0], expected[name], 0.001)
                         del expected[name]
 

--- a/contrib/testmpi/test_mpi.py
+++ b/contrib/testmpi/test_mpi.py
@@ -321,53 +321,8 @@ class MPITests1(MPITestCase):
         if self.comm.rank == 0:
             self.assertTrue(all(top.C4.a==np.ones(size, float)*11.))
             self.assertTrue(all(top.C4.b==np.ones(size, float)*5.))
+
             
-    def test_serial_under_par(self):
-        
-        class MyDriver(SimpleDriver):
-
-            implements(ISolver)
-            
-            def execute(self):
-               # Direct uvec setting
-                uvec = self._system.vec['u']
-                print uvec.keys()
-                # Only can interact with the var that is in our node
-                for num in [1.0, 2.0, 3.0]:
-                    if 'comp1.x' in uvec:
-                        uvec['comp1.x'] = num
-                        print "SETTING", 'comp1.x', uvec['comp1.x']
-                    if 'comp2.x' in uvec:
-                        uvec['comp2.x'] = num
-                        print "SETTING", 'comp2.x', uvec['comp2.x']
-                        
-                    self.run_iteration()
-
-            def requires_derivs(self):
-                return False
-        
-        top = set_as_top(Assembly())
-        top.add('driver', MyDriver())
-        top.add('comp1', ExecComp(['y = 2.0*x']))
-        top.add('comp2', ExecComp(['y = 1.0*x']))
-        top.driver.workflow.add(['comp1', 'comp2'])
-        top.driver.add_parameter('comp1.x', low=-100, high=100)
-        top.driver.add_parameter('comp2.x', low=-100, high=100)
-        top.driver.add_constraint('comp1.y = comp2.x')
-        top.driver.add_constraint('comp2.y = comp1.x')
-        
-        top.run()
-        print top.comp1.x, 'should be 3.0'
-        print top.comp2.x, 'should be 3.0'
-        
-        #if self.comm.rank == 0:
-            #from openmdao.util.dotgraph import plot_system_tree, plot_graphs
-            #plot_system_tree(top.driver.workflow._system)
-            #plot_graphs(top, prefix='works')
-
-        self.collective_assertTrue(top.comp1.x==3.0)
-        self.collective_assertTrue(top.comp2.x==3.0)
-        
 class MPITests2(MPITestCase):
 
     N_PROCS = 2

--- a/contrib/testmpi/test_mpi.py
+++ b/contrib/testmpi/test_mpi.py
@@ -321,8 +321,47 @@ class MPITests1(MPITestCase):
         if self.comm.rank == 0:
             self.assertTrue(all(top.C4.a==np.ones(size, float)*11.))
             self.assertTrue(all(top.C4.b==np.ones(size, float)*5.))
-
             
+    def test_serial_under_par(self):
+        
+        class MyDriver(SimpleDriver):
+
+            implements(ISolver)
+            
+            def execute(self):
+               # Direct uvec setting
+                uvec = self._system.vec['u']
+                print uvec.keys()
+                # Only can interact with the var that is in our node
+                for num in [1.0, 2.0, 3.0]:
+                    if 'comp1.x' in uvec:
+                        uvec['comp1.x'] = num
+                        print "SETTING", 'comp1.x', uvec['comp1.x']
+                    if 'comp2.x' in uvec:
+                        uvec['comp2.x'] = num
+                        print "SETTING", 'comp2.x', uvec['comp2.x']
+                        
+                    self.run_iteration()
+
+            def requires_derivs(self):
+                return False
+        
+        top = set_as_top(Assembly())
+        top.add('driver', MyDriver())
+        top.add('comp1', ExecComp(['y = 2.0*x']))
+        top.add('comp2', ExecComp(['y = 1.0*x']))
+        top.driver.workflow.add(['comp1', 'comp2'])
+        top.driver.add_parameter('comp1.x', low=-100, high=100)
+        top.driver.add_parameter('comp2.x', low=-100, high=100)
+        top.driver.add_constraint('comp1.y = comp2.x')
+        top.driver.add_constraint('comp2.y = comp1.x')
+        
+        top.run()
+        
+        self.collective_assertTrue(top.comp1.x==3.0)
+        self.collective_assertTrue(top.comp2.x==3.0)
+        
+        
 class MPITests2(MPITestCase):
 
     N_PROCS = 2

--- a/contrib/testmpi/test_mpi_derivatives.py
+++ b/contrib/testmpi/test_mpi_derivatives.py
@@ -261,7 +261,7 @@ class MPITests(MPITestCase):
                                     J['_pseudo_1.out0']['comp1.x'][0][0], 
                                     20.0, 0.0001)        
 
-    def test_three_way_forward(self):
+    def test_three_comp_diamond_forward(self):
         
         self.top = set_as_top(Assembly())
 
@@ -290,13 +290,13 @@ class MPITests(MPITestCase):
         self.top.comp1.x1 = 2.0
         self.top.run()
 
-        # from openmdao.util.dotgraph import plot_system_tree
-        # plot_system_tree(self.top.driver.workflow._system)
+        from openmdao.util.dotgraph import plot_system_tree
+        plot_system_tree(self.top.driver.workflow._system)
         
-        #J = self.top.driver.calc_gradient(inputs=['comp1.x1'],
-        #                                  outputs=['comp3.y1'],
-        #                                  mode='forward')
-        #print J
+        J = self.top.driver.calc_gradient(inputs=['comp1.x1'],
+                                          outputs=['comp3.y1'],
+                                          mode='forward')
+        print J
         #collective_assert_rel_error(self, J[0][0], 24048,0, 0.0001)
 
 

--- a/contrib/testmpi/test_mpi_derivatives.py
+++ b/contrib/testmpi/test_mpi_derivatives.py
@@ -114,6 +114,24 @@ class MPITests_2Proc(MPITestCase):
                                     J['_pseudo_0.out0']['comp.y'][0][0], 
                                     21.0, 0.0001)
         
+    def test_calc_gradient_fwd_linGS(self):
+        
+        self.top.driver.gradient_options.lin_solver = 'linear_gs'
+        self.top.driver.gradient_options.maxiter = 1
+        self.top.run()
+
+        J = self.top.driver.calc_gradient(inputs=['comp.x'], mode='forward',
+                                          return_format='dict')
+
+        J = self.top.driver.workflow._system.get_combined_J(J)
+
+        collective_assert_rel_error(self, 
+                                    J['_pseudo_0.out0']['comp.x'][0][0], 
+                                    5.0, 0.0001)
+        collective_assert_rel_error(self, 
+                                    J['_pseudo_0.out0']['comp.y'][0][0], 
+                                    21.0, 0.0001)
+
     def test_two_to_one_forward(self):
         
         top = set_as_top(Assembly())

--- a/contrib/testmpi/test_mpi_derivatives.py
+++ b/contrib/testmpi/test_mpi_derivatives.py
@@ -295,7 +295,8 @@ class MPITests(MPITestCase):
         
         J = self.top.driver.calc_gradient(inputs=['comp1.x1'],
                                           outputs=['comp3.y1'],
-                                          mode='forward')
+                                          mode='forward',
+                                          return_format='dict')
         print J
         #collective_assert_rel_error(self, J[0][0], 24048,0, 0.0001)
 

--- a/contrib/testmpi/test_mpi_derivatives.py
+++ b/contrib/testmpi/test_mpi_derivatives.py
@@ -251,8 +251,8 @@ class MPITests_2Proc(MPITestCase):
         J = top.driver.workflow._system.get_combined_J(J)
         print J
 
-        from openmdao.util.dotgraph import plot_system_tree
-        plot_system_tree(top._system)
+        #from openmdao.util.dotgraph import plot_system_tree
+        #plot_system_tree(top._system)
 
         collective_assert_rel_error(self, 
                                     J['_pseudo_0.out0']['comp1.x'][0][0], 

--- a/contrib/testmpi/test_mpi_derivatives.py
+++ b/contrib/testmpi/test_mpi_derivatives.py
@@ -280,6 +280,7 @@ class MPITests(MPITestCase):
         self.top.add('comp1', ExecCompWithDerivatives(exp1, deriv1))
         self.top.add('comp2', ExecCompWithDerivatives(exp2, deriv2))
         self.top.add('comp3', ExecCompWithDerivatives(exp3, deriv3))
+        self.top.add('driver', SimpleDriver())
 
         self.top.driver.workflow.add(['comp1', 'comp2', 'comp3'])
 
@@ -287,6 +288,8 @@ class MPITests(MPITestCase):
         self.top.connect('comp1.y2', 'comp3.x1')
         self.top.connect('comp2.y1', 'comp3.x2')
 
+        self.top.driver.add_parameter('comp1.x1', low=-100, high=100)
+        self.top.driver.add_objective('comp3.y1')
         self.top.comp1.x1 = 2.0
         self.top.run()
 

--- a/contrib/testmpi/test_mpi_derivatives.py
+++ b/contrib/testmpi/test_mpi_derivatives.py
@@ -44,7 +44,7 @@ class Paraboloid(Component):
         return input_keys, output_keys
 
 
-class MPITests(MPITestCase):
+class MPITests_2Proc(MPITestCase):
 
     N_PROCS = 2
 
@@ -149,18 +149,17 @@ class MPITests(MPITestCase):
         collective_assert_rel_error(self,
                                     J['_pseudo_0.out0']['comp2.x'][0][0], 
                                     -8.0, 0.0001)        
-
-    def test_one_to_two_forward(self):
+    def test_two_to_one_adjoint(self):
         
         top = set_as_top(Assembly())
         
-        exp1 = ["y1 = 3.0*x", "y2 = 4.0*x"]
+        exp1 = ["y = 3.0*x"]
         exp2 = ["y = -2.0*x"]
-        exp3 = ["y = 5.0*x"]
+        exp3 = ["y = 5.0*x1 + 4.0*x2"]
         
-        deriv1 = ["dy1_dx = 3.0", "dy2_dx = 4.0"]
+        deriv1 = ["dy_dx = 3.0"]
         deriv2 = ["dy_dx = -2.0"]
-        deriv3 = ["dy_dx = 5.0"]
+        deriv3 = ["dy_dx1 = 5.0", "dy_dx2 = 4.0"]
         
         top.add('comp1', ExecCompWithDerivatives(exp1, deriv1))
         top.add('comp2', ExecCompWithDerivatives(exp2, deriv2))
@@ -168,26 +167,96 @@ class MPITests(MPITestCase):
         top.add('driver', SimpleDriver())
         
         top.driver.workflow.add(['comp1', 'comp2', 'comp3'])
-        top.connect('comp1.y1', 'comp2.x')
-        top.connect('comp1.y2', 'comp3.x')
+        top.connect('comp1.y', 'comp3.x1')
+        top.connect('comp2.y', 'comp3.x2')
         top.driver.add_parameter('comp1.x', low=-100, high=100)
-        top.driver.add_constraint('comp2.y < 1000')
+        top.driver.add_parameter('comp2.x', low=-100, high=100)
         top.driver.add_constraint('comp3.y < 1000')
         top.run()
-        
-        #from openmdao.util.dotgraph import plot_system_tree
-        #plot_system_tree(top.driver._system)
-        J = top.driver.workflow.calc_gradient(mode='forward',
+
+        J = top.driver.workflow.calc_gradient(mode='adjoint',
                                               return_format='dict')
-        
+
         J = top.driver.workflow._system.get_combined_J(J)
-        
         collective_assert_rel_error(self, 
                                     J['_pseudo_0.out0']['comp1.x'][0][0], 
-                                    -6.0, 0.0001)
+                                    15.0, 0.0001)
         collective_assert_rel_error(self,
-                                    J['_pseudo_1.out0']['comp1.x'][0][0], 
-                                    20.0, 0.0001)        
+                                    J['_pseudo_0.out0']['comp2.x'][0][0], 
+                                    -8.0, 0.0001)        
+
+    def test_two_to_one_forward_bcast(self):
+        
+        top = set_as_top(Assembly())
+        
+        exp1 = ["y = 3.0*x"]
+        exp2 = ["y = -2.0*x"]
+        exp3 = ["y = 5.0*x1 + 4.0*x2"]
+        
+        deriv1 = ["dy_dx = 3.0"]
+        deriv2 = ["dy_dx = -2.0"]
+        deriv3 = ["dy_dx1 = 5.0", "dy_dx2 = 4.0"]
+        
+        top.add('comp1', ExecCompWithDerivatives(exp1, deriv1))
+        top.add('comp2', ExecCompWithDerivatives(exp2, deriv2))
+        top.add('comp3', ExecCompWithDerivatives(exp3, deriv3))
+        top.add('driver', SimpleDriver())
+        
+        top.driver.workflow.add(['comp1', 'comp2', 'comp3'])
+        top.connect('comp1.y', 'comp3.x1')
+        top.connect('comp2.y', 'comp3.x2')
+        top.driver.add_parameter(('comp1.x', 'comp2.x'), 
+                                 low=-100, high=100)
+        top.driver.add_constraint('comp3.y < 1000')
+        top.run()
+
+        J = top.driver.workflow.calc_gradient(mode='forward',
+                                              return_format='dict')
+
+        J = top.driver.workflow._system.get_combined_J(J)
+        print J
+        collective_assert_rel_error(self, 
+                                    J['_pseudo_0.out0']['comp1.x'][0][0], 
+                                    7.0, 0.0001)
+
+    def test_two_to_one_adjoint_bcast(self):
+        
+        top = set_as_top(Assembly())
+        
+        exp1 = ["y = 3.0*x"]
+        exp2 = ["y = -2.0*x"]
+        exp3 = ["y = 5.0*x1 + 4.0*x2"]
+        
+        deriv1 = ["dy_dx = 3.0"]
+        deriv2 = ["dy_dx = -2.0"]
+        deriv3 = ["dy_dx1 = 5.0", "dy_dx2 = 4.0"]
+        
+        top.add('comp1', ExecCompWithDerivatives(exp1, deriv1))
+        top.add('comp2', ExecCompWithDerivatives(exp2, deriv2))
+        top.add('comp3', ExecCompWithDerivatives(exp3, deriv3))
+        top.add('driver', SimpleDriver())
+        
+        top.driver.workflow.add(['comp1', 'comp2', 'comp3'])
+        top.connect('comp1.y', 'comp3.x1')
+        top.connect('comp2.y', 'comp3.x2')
+        top.driver.add_parameter(('comp1.x', 'comp2.x'), 
+                                 low=-100, high=100)
+        top.driver.add_constraint('comp3.y < 1000')
+        top.run()
+
+        J = top.driver.workflow.calc_gradient(mode='adjoint',
+                                              return_format='dict')
+
+        print J
+        J = top.driver.workflow._system.get_combined_J(J)
+        print J
+
+        from openmdao.util.dotgraph import plot_system_tree
+        plot_system_tree(top._system)
+
+        collective_assert_rel_error(self, 
+                                    J['_pseudo_0.out0']['comp1.x'][0][0], 
+                                    7.0, 0.0001)
 
     def test_one_to_two_forward(self):
         
@@ -293,16 +362,131 @@ class MPITests(MPITestCase):
         self.top.comp1.x1 = 2.0
         self.top.run()
 
-        from openmdao.util.dotgraph import plot_system_tree
-        plot_system_tree(self.top._system)
-        
         J = self.top.driver.calc_gradient(inputs=['comp1.x1'],
                                           outputs=['comp3.y1'],
                                           mode='forward',
                                           return_format='dict')
-        print J
-        #collective_assert_rel_error(self, J[0][0], 24048,0, 0.0001)
+        if self.comm.rank == 0:
+            assert_rel_error(self, J['comp3.y1']['comp1.x1'][0][0], 
+                             24048.0, 0.0001)
 
+    def test_diverge_converge_forward(self):
+        
+        self.top = set_as_top(Assembly())
+
+        exp1 = ['y1 = 2.0*x1**2',
+                'y2 = 3.0*x1']
+        deriv1 = ['dy1_dx1 = 4.0*x1',
+                  'dy2_dx1 = 3.0']
+
+        exp2 = ['y1 = 0.5*x1']
+        deriv2 = ['dy1_dx1 = 0.5']
+
+        exp3 = ['y1 = 3.5*x1']
+        deriv3 = ['dy1_dx1 = 3.5']
+
+        exp4 = ['y1 = x1 + 2.0*x2',
+                'y2 = 3.0*x1',
+                'y3 = x1*x2']
+        deriv4 = ['dy1_dx1 = 1.0',
+                  'dy1_dx2 = 2.0',
+                  'dy2_dx1 = 3.0',
+                  'dy2_dx2 = 0.0',
+                  'dy3_dx1 = x2',
+                  'dy3_dx2 = x1']
+
+        exp5 = ['y1 = x1 + 3.0*x2 + 2.0*x3']
+        deriv5 = ['dy1_dx1 = 1.0',
+                  'dy1_dx2 = 3.0',
+                  'dy1_dx3 = 2.0']
+
+        self.top.add('comp1', ExecCompWithDerivatives(exp1, deriv1))
+        self.top.add('comp2', ExecCompWithDerivatives(exp2, deriv2))
+        self.top.add('comp3', ExecCompWithDerivatives(exp3, deriv3))
+        self.top.add('comp4', ExecCompWithDerivatives(exp4, deriv4))
+        self.top.add('comp5', ExecCompWithDerivatives(exp5, deriv5))
+
+        self.top.driver.workflow.add(['comp1', 'comp2', 'comp3', 'comp4', 'comp5'])
+
+        self.top.connect('comp1.y1', 'comp2.x1')
+        self.top.connect('comp1.y2', 'comp3.x1')
+        self.top.connect('comp2.y1', 'comp4.x1')
+        self.top.connect('comp3.y1', 'comp4.x2')
+        self.top.connect('comp4.y1', 'comp5.x1')
+        self.top.connect('comp4.y2', 'comp5.x2')
+        self.top.connect('comp4.y3', 'comp5.x3')
+        
+        self.top.comp1.x1 = 2.0        
+        self.top.run()
+
+        J = self.top.driver.calc_gradient(inputs=['comp1.x1'],
+                                          outputs=['comp5.y1'],
+                                          mode='forward',
+                                          return_format='dict')
+        
+        collective_assert_rel_error(self, 
+                                    J['comp5.y1']['comp1.x1'][0][0], 
+                                    313.0, 0.0001)
+
+    def test_diverge_converge_adjoint(self):
+        
+        self.top = set_as_top(Assembly())
+
+        exp1 = ['y1 = 2.0*x1**2',
+                'y2 = 3.0*x1']
+        deriv1 = ['dy1_dx1 = 4.0*x1',
+                  'dy2_dx1 = 3.0']
+
+        exp2 = ['y1 = 0.5*x1']
+        deriv2 = ['dy1_dx1 = 0.5']
+
+        exp3 = ['y1 = 3.5*x1']
+        deriv3 = ['dy1_dx1 = 3.5']
+
+        exp4 = ['y1 = x1 + 2.0*x2',
+                'y2 = 3.0*x1',
+                'y3 = x1*x2']
+        deriv4 = ['dy1_dx1 = 1.0',
+                  'dy1_dx2 = 2.0',
+                  'dy2_dx1 = 3.0',
+                  'dy2_dx2 = 0.0',
+                  'dy3_dx1 = x2',
+                  'dy3_dx2 = x1']
+
+        exp5 = ['y1 = x1 + 3.0*x2 + 2.0*x3']
+        deriv5 = ['dy1_dx1 = 1.0',
+                  'dy1_dx2 = 3.0',
+                  'dy1_dx3 = 2.0']
+
+        self.top.add('comp1', ExecCompWithDerivatives(exp1, deriv1))
+        self.top.add('comp2', ExecCompWithDerivatives(exp2, deriv2))
+        self.top.add('comp3', ExecCompWithDerivatives(exp3, deriv3))
+        self.top.add('comp4', ExecCompWithDerivatives(exp4, deriv4))
+        self.top.add('comp5', ExecCompWithDerivatives(exp5, deriv5))
+
+        self.top.driver.workflow.add(['comp1', 'comp2', 'comp3', 'comp4', 'comp5'])
+
+        self.top.connect('comp1.y1', 'comp2.x1')
+        self.top.connect('comp1.y2', 'comp3.x1')
+        self.top.connect('comp2.y1', 'comp4.x1')
+        self.top.connect('comp3.y1', 'comp4.x2')
+        self.top.connect('comp4.y1', 'comp5.x1')
+        self.top.connect('comp4.y2', 'comp5.x2')
+        self.top.connect('comp4.y3', 'comp5.x3')
+        
+        self.top.comp1.x1 = 2.0        
+        self.top.run()
+
+        J = self.top.driver.calc_gradient(inputs=['comp1.x1'],
+                                          outputs=['comp5.y1'],
+                                          mode='adjoint',
+                                          return_format='dict')
+        #from openmdao.util.dotgraph import plot_system_tree
+        #plot_system_tree(self.top._system)
+        print J
+        collective_assert_rel_error(self, 
+                                    J['comp5.y1']['comp1.x1'][0][0], 
+                                    313.0, 0.0001)
 
 if __name__ == '__main__':
     import unittest

--- a/contrib/testmpi/test_mpi_derivatives.py
+++ b/contrib/testmpi/test_mpi_derivatives.py
@@ -7,7 +7,7 @@ from openmdao.test.mpiunittest import MPITestCase, collective_assert_rel_error, 
 from openmdao.main.api import Assembly, Component, set_as_top
 from openmdao.main.datatypes.api import Float
 from openmdao.main.test.simpledriver import SimpleDriver
-from openmdao.test.execcomp import ExecCompWithDerivatives
+from openmdao.test.execcomp import ExecCompWithDerivatives, ExecComp
 
 class Paraboloid(Component):
     """ Evaluates the equation f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3 """
@@ -557,6 +557,69 @@ class MPITests_2Proc(MPITestCase):
         collective_assert_rel_error(self, 
                                     J['comp5.y1']['comp1.x1'][0][0], 
                                     313.0, 0.0001)
+
+    def test_diverge_converge_nondiff_comp3_forward(self):
+        
+        self.top = set_as_top(Assembly())
+
+        exp1 = ['y1 = 2.0*x1**2',
+                'y2 = 3.0*x1']
+        deriv1 = ['dy1_dx1 = 4.0*x1',
+                  'dy2_dx1 = 3.0']
+
+        exp2 = ['y1 = 0.5*x1']
+        deriv2 = ['dy1_dx1 = 0.5']
+
+        exp3 = ['y1 = 3.5*x1']
+        deriv3 = ['dy1_dx1 = 3.5']
+
+        exp4 = ['y1 = x1 + 2.0*x2',
+                'y2 = 3.0*x1',
+                'y3 = x1*x2']
+        deriv4 = ['dy1_dx1 = 1.0',
+                  'dy1_dx2 = 2.0',
+                  'dy2_dx1 = 3.0',
+                  'dy2_dx2 = 0.0',
+                  'dy3_dx1 = x2',
+                  'dy3_dx2 = x1']
+
+        exp5 = ['y1 = x1 + 3.0*x2 + 2.0*x3']
+        deriv5 = ['dy1_dx1 = 1.0',
+                  'dy1_dx2 = 3.0',
+                  'dy1_dx3 = 2.0']
+        
+        self.top.add('driver', SimpleDriver())
+        self.top.add('comp1', ExecCompWithDerivatives(exp1, deriv1))
+        self.top.add('comp2', ExecCompWithDerivatives(exp2, deriv2))
+        self.top.add('comp3', ExecComp(exp3))
+        self.top.add('comp4', ExecCompWithDerivatives(exp4, deriv4))
+        self.top.add('comp5', ExecCompWithDerivatives(exp5, deriv5))
+
+        self.top.driver.workflow.add(['comp1', 'comp2', 'comp3', 'comp4', 'comp5'])
+
+        self.top.connect('comp1.y1', 'comp2.x1')
+        self.top.connect('comp1.y2', 'comp3.x1')
+        self.top.connect('comp2.y1', 'comp4.x1')
+        self.top.connect('comp3.y1', 'comp4.x2')
+        self.top.connect('comp4.y1', 'comp5.x1')
+        self.top.connect('comp4.y2', 'comp5.x2')
+        self.top.connect('comp4.y3', 'comp5.x3')
+        
+        self.top.driver.add_parameter('comp1.x1', low=-100, high=100)
+        self.top.driver.add_objective('comp5.y1')
+        
+        self.top.comp1.x1 = 2.0        
+        self.top.run()
+
+        J = self.top.driver.calc_gradient(inputs=['comp1.x1'],
+                                          outputs=['comp5.y1'],
+                                          mode='forward',
+                                          return_format='dict')
+        
+        collective_assert_rel_error(self, 
+                                    J['comp5.y1']['comp1.x1'][0][0], 
+                                    313.0, 0.0001)
+
 
 if __name__ == '__main__':
     import unittest

--- a/contrib/testmpi/test_mpi_derivatives.py
+++ b/contrib/testmpi/test_mpi_derivatives.py
@@ -143,7 +143,6 @@ class MPITests(MPITestCase):
                                               return_format='dict')
 
         J = top.driver.workflow._system.get_combined_J(J)
-        print J
         collective_assert_rel_error(self, 
                                     J['_pseudo_0.out0']['comp1.x'][0][0], 
                                     15.0, 0.0001)

--- a/contrib/testmpi/test_mpi_derivatives.py
+++ b/contrib/testmpi/test_mpi_derivatives.py
@@ -214,7 +214,7 @@ class MPITests_2Proc(MPITestCase):
                                               return_format='dict')
 
         J = top.driver.workflow._system.get_combined_J(J)
-        print J
+        #print J
         collective_assert_rel_error(self, 
                                     J['_pseudo_0.out0']['comp1.x'][0][0], 
                                     7.0, 0.0001)
@@ -247,9 +247,9 @@ class MPITests_2Proc(MPITestCase):
         J = top.driver.workflow.calc_gradient(mode='adjoint',
                                               return_format='dict')
 
-        print J
+        #print J
         J = top.driver.workflow._system.get_combined_J(J)
-        print J
+        #print J
 
         #from openmdao.util.dotgraph import plot_system_tree
         #plot_system_tree(top._system)
@@ -483,7 +483,7 @@ class MPITests_2Proc(MPITestCase):
                                           return_format='dict')
         #from openmdao.util.dotgraph import plot_system_tree
         #plot_system_tree(self.top._system)
-        print J
+        #print J
         collective_assert_rel_error(self, 
                                     J['comp5.y1']['comp1.x1'][0][0], 
                                     313.0, 0.0001)

--- a/contrib/testmpi/test_mpi_derivatives.py
+++ b/contrib/testmpi/test_mpi_derivatives.py
@@ -185,6 +185,42 @@ class MPITests_2Proc(MPITestCase):
                                     J['_pseudo_0.out0']['comp2.x'][0][0], 
                                     -8.0, 0.0001)        
 
+    def test_two_to_one_fd(self):
+        
+        top = set_as_top(Assembly())
+        
+        exp1 = ["y = 3.0*x"]
+        exp2 = ["y = -2.0*x"]
+        exp3 = ["y = 5.0*x1 + 4.0*x2"]
+        
+        deriv1 = ["dy_dx = 3.0"]
+        deriv2 = ["dy_dx = -2.0"]
+        deriv3 = ["dy_dx1 = 5.0", "dy_dx2 = 4.0"]
+        
+        top.add('comp1', ExecCompWithDerivatives(exp1, deriv1))
+        top.add('comp2', ExecCompWithDerivatives(exp2, deriv2))
+        top.add('comp3', ExecCompWithDerivatives(exp3, deriv3))
+        top.add('driver', SimpleDriver())
+        
+        top.driver.workflow.add(['comp1', 'comp2', 'comp3'])
+        top.connect('comp1.y', 'comp3.x1')
+        top.connect('comp2.y', 'comp3.x2')
+        top.driver.add_parameter('comp1.x', low=-100, high=100)
+        top.driver.add_parameter('comp2.x', low=-100, high=100)
+        top.driver.add_constraint('comp3.y < 1000')
+        top.run()
+
+        J = top.driver.workflow.calc_gradient(mode='fd',
+                                              return_format='dict')
+
+        J = top.driver.workflow._system.get_combined_J(J)
+        collective_assert_rel_error(self, 
+                                    J['_pseudo_0.out0']['comp1.x'][0][0], 
+                                    15.0, 0.0001)
+        collective_assert_rel_error(self,
+                                    J['_pseudo_0.out0']['comp2.x'][0][0], 
+                                    -8.0, 0.0001)        
+
     def test_two_to_one_forward_bcast(self):
         
         top = set_as_top(Assembly())
@@ -247,9 +283,7 @@ class MPITests_2Proc(MPITestCase):
         J = top.driver.workflow.calc_gradient(mode='adjoint',
                                               return_format='dict')
 
-        #print J
         J = top.driver.workflow._system.get_combined_J(J)
-        #print J
 
         #from openmdao.util.dotgraph import plot_system_tree
         #plot_system_tree(top._system)
@@ -320,6 +354,42 @@ class MPITests_2Proc(MPITestCase):
         top.run()
         
         J = top.driver.workflow.calc_gradient(mode='adjoint',
+                                              return_format='dict')
+        J = top.driver.workflow._system.get_combined_J(J)
+        
+        collective_assert_rel_error(self, 
+                                    J['_pseudo_0.out0']['comp1.x'][0][0], 
+                                    -6.0, 0.0001)
+        collective_assert_rel_error(self,
+                                    J['_pseudo_1.out0']['comp1.x'][0][0], 
+                                    20.0, 0.0001)        
+
+    def test_one_to_two_fd(self):
+        
+        top = set_as_top(Assembly())
+        
+        exp1 = ["y1 = 3.0*x", "y2 = 4.0*x"]
+        exp2 = ["y = -2.0*x"]
+        exp3 = ["y = 5.0*x"]
+        
+        deriv1 = ["dy1_dx = 3.0", "dy2_dx = 4.0"]
+        deriv2 = ["dy_dx = -2.0"]
+        deriv3 = ["dy_dx = 5.0"]
+        
+        top.add('comp1', ExecCompWithDerivatives(exp1, deriv1))
+        top.add('comp2', ExecCompWithDerivatives(exp2, deriv2))
+        top.add('comp3', ExecCompWithDerivatives(exp3, deriv3))
+        top.add('driver', SimpleDriver())
+        
+        top.driver.workflow.add(['comp1', 'comp2', 'comp3'])
+        top.connect('comp1.y1', 'comp2.x')
+        top.connect('comp1.y2', 'comp3.x')
+        top.driver.add_parameter('comp1.x', low=-100, high=100)
+        top.driver.add_constraint('comp2.y < 1000')
+        top.driver.add_constraint('comp3.y < 1000')
+        top.run()
+        
+        J = top.driver.workflow.calc_gradient(mode='fd',
                                               return_format='dict')
         J = top.driver.workflow._system.get_combined_J(J)
         

--- a/openmdao.lib/src/openmdao/lib/casehandlers/test/test_recording_options.py
+++ b/openmdao.lib/src/openmdao/lib/casehandlers/test/test_recording_options.py
@@ -27,20 +27,20 @@ class RecordingOptionsTestCase(unittest.TestCase):
         self.top.driver.add_objective('comp2.z')
 
     def test_no_recorder(self):
-        """ verify recording options are ignored if there are no recorders
-             (i.e. the Assembly runs without errors)
-        """
+        # verify recording options are ignored if there are no recorders
+        #    (i.e. the Assembly runs without errors)
+        
         self.top.recorders = []
         self.top.run()
         self.assertEqual(self.top.comp1.z, 0.0)
         self.assertEqual(self.top.comp2.z, 1.0)
 
     def test_default_options(self):
-        """ verify default options:
-                save_problem_formulation = True
-                includes = ['*']
-                excludes = []
-        """
+        # verify default options:
+        #        save_problem_formulation = True
+        #        includes = ['*']
+        #        excludes = []
+        
         sout = StringIO.StringIO()
         self.top.recorders = [JSONCaseRecorder(sout)]
         self.top.run()

--- a/openmdao.lib/src/openmdao/lib/drivers/iterate.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/iterate.py
@@ -80,15 +80,11 @@ class FixedPointIterator(Driver):
         uvec = system.vec['u']
         fvec = system.vec['f']
 
-        #print 'old u', uvec.array, uvec.keys()
-        #print 'f', fvec.array
         cycle_vars = self.workflow._cycle_vars
         for name in uvec.keys():
             if name not in cycle_vars:
                 uvec[name] -= fvec[name]
-                #print "COMMAND", name, uvec[name]
 
-        #print 'new u', uvec.array
         self.workflow.run()
 
     def continue_iteration(self):

--- a/openmdao.lib/src/openmdao/lib/drivers/newton_solver.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/newton_solver.py
@@ -95,7 +95,7 @@ class NewtonSolver(Driver):
 
             system.calc_newton_direction(options=options)
 
-            print "LS 1", uvec.array, '+', dfvec.array
+            #print "LS 1", uvec.array, '+', dfvec.array
             uvec.array += alpha*dfvec.array
 
             # Just evaluate the model with the new points

--- a/openmdao.main/src/openmdao/main/finite_difference.py
+++ b/openmdao.main/src/openmdao/main/finite_difference.py
@@ -180,7 +180,7 @@ class FiniteDifference(object):
             outputs = [out for out in self.outputs 
                        if out in self.system.vec['u']]
         else:
-            ouputs = self.outputs
+            outputs = self.outputs
             
         uvec.set_to_array(self.y_base, outputs)
 

--- a/openmdao.main/src/openmdao/main/linearsolver.py
+++ b/openmdao.main/src/openmdao/main/linearsolver.py
@@ -27,8 +27,8 @@ class LinearSolver(object):
         system.rhs_vec.array[:] += system.rhs_buf[:]
 
         if MPI:
-            system.rhs_vec.petsc.assemble()
-            return system.rhs_vec.petsc.norm()
+            system.rhs_vec.petsc_vec.assemble()
+            return system.rhs_vec.petsc_vec.norm()
         else:
             return np.linalg.norm(system.rhs_vec.array)
 
@@ -385,6 +385,11 @@ class LinearGS(LinearSolver):
 
         if system.mode == 'adjoint':
             outputs, inputs = inputs, outputs
+            invec = system.vec['u']
+            outvec = system.vec['p']
+        else:
+            invec = system.vec['p']
+            outvec = system.vec['u']
 
         # If Forward mode, solve linear system for each parameter
         # If Reverse mode, solve linear system for each requested output
@@ -394,7 +399,7 @@ class LinearGS(LinearSolver):
             if isinstance(param, tuple):
                 param = param[0]
 
-            in_indices = system.vec['u'].indices(system.scope, param)
+            in_indices = invec.indices(system.scope, param)
             jbase = j
 
             for irhs in in_indices:
@@ -415,7 +420,7 @@ class LinearGS(LinearSolver):
                     if isinstance(item, tuple):
                         item = item[0]
 
-                    out_indices = system.vec['u'].indices(system.scope, item)
+                    out_indices = outvec.indices(system.scope, item)
                     nk = len(out_indices)
 
                     if return_format == 'dict':
@@ -455,16 +460,22 @@ class LinearGS(LinearSolver):
               norm/norm0 > options.rtol:
 
             if system.mode == 'forward':
+                print "Start", system.name, system
                 for subsystem in system.subsystems(local=True):
+                    print "Z1", system.vec['du'].array, system.vec['dp'].array, system.vec['df'].array
                     system.scatter('du', 'dp', subsystem=subsystem)
+                    print "Z2", system.vec['du'].array, system.vec['dp'].array, system.vec['df'].array
                     system.rhs_vec.array[:] = 0.0
                     subsystem.applyJ(system.flat_vars.keys())
                     system.rhs_vec.array[:] *= -1.0
                     system.rhs_vec.array[:] += system.rhs_buf[:]
                     sub_options = options if subsystem.options is None \
                                           else subsystem.options
+                    print "Z4", system.vec['du'].array, system.vec['dp'].array, system.vec['df'].array
                     subsystem.solve_linear(sub_options)
-
+                    print "Z5", system.vec['du'].array, system.vec['dp'].array, system.vec['df'].array
+                    print subsystem.name, system.rhs_vec.array, system.sol_vec.array
+                print "End", system.name
             elif system.mode == 'adjoint':
 
                 rev_systems = [item for item in reversed(system.subsystems(local=True))]

--- a/openmdao.main/src/openmdao/main/linearsolver.py
+++ b/openmdao.main/src/openmdao/main/linearsolver.py
@@ -242,6 +242,10 @@ class PETSc_KSP(LinearSolver):
 
         j = 0
         for param in inputs:
+
+            if isinstance(param, tuple):
+                param = param[0]
+
             param_tup = name2collapsed[param]
             param_size = system.get_size(param)
 
@@ -254,6 +258,10 @@ class PETSc_KSP(LinearSolver):
 
                 i = 0
                 for out in outputs:
+                    
+                    if isinstance(out, tuple):
+                        out = out[0]
+                    
                     out_size = system.get_size(out)
 
                     if return_format == 'dict':

--- a/openmdao.main/src/openmdao/main/linearsolver.py
+++ b/openmdao.main/src/openmdao/main/linearsolver.py
@@ -460,22 +460,22 @@ class LinearGS(LinearSolver):
               norm/norm0 > options.rtol:
 
             if system.mode == 'forward':
-                print "Start", system.name, system
+                #print "Start", system.name, system
                 for subsystem in system.subsystems(local=True):
-                    print "Z1", system.vec['du'].array, system.vec['dp'].array, system.vec['df'].array
+                    #print "Z1", system.vec['du'].array, system.vec['dp'].array, system.vec['df'].array
                     system.scatter('du', 'dp', subsystem=subsystem)
-                    print "Z2", system.vec['du'].array, system.vec['dp'].array, system.vec['df'].array
+                    #print "Z2", system.vec['du'].array, system.vec['dp'].array, system.vec['df'].array
                     system.rhs_vec.array[:] = 0.0
                     subsystem.applyJ(system.flat_vars.keys())
                     system.rhs_vec.array[:] *= -1.0
                     system.rhs_vec.array[:] += system.rhs_buf[:]
                     sub_options = options if subsystem.options is None \
                                           else subsystem.options
-                    print "Z4", system.vec['du'].array, system.vec['dp'].array, system.vec['df'].array
+                    #print "Z4", system.vec['du'].array, system.vec['dp'].array, system.vec['df'].array
                     subsystem.solve_linear(sub_options)
-                    print "Z5", system.vec['du'].array, system.vec['dp'].array, system.vec['df'].array
-                    print subsystem.name, system.rhs_vec.array, system.sol_vec.array
-                print "End", system.name
+                    #print "Z5", system.vec['du'].array, system.vec['dp'].array, system.vec['df'].array
+                    #print subsystem.name, system.rhs_vec.array, system.sol_vec.array
+                #print "End", system.name
             elif system.mode == 'adjoint':
 
                 rev_systems = [item for item in reversed(system.subsystems(local=True))]

--- a/openmdao.main/src/openmdao/main/systems.py
+++ b/openmdao.main/src/openmdao/main/systems.py
@@ -189,7 +189,7 @@ class System(object):
             for param, value in dct.items():
                 
                 # Params are already only on this process. We need to add
-                # only outputs that are on this process.
+                # only outputs of components that are on this process.
                 comp = self.scope.get(output.partition('.')[0])
                 sys = self.find_system(comp.name)
                 if sys.is_active():

--- a/openmdao.main/src/openmdao/main/systems.py
+++ b/openmdao.main/src/openmdao/main/systems.py
@@ -190,8 +190,7 @@ class System(object):
                 
                 # Params are already only on this process. We need to add
                 # only outputs of components that are on this process.
-                comp = self.scope.get(output.partition('.')[0])
-                sys = self.find_system(comp.name)
+                sys = self.find_system(output.partition('.')[0])
                 if sys.is_active():
                     tups.append((output, param))
 

--- a/openmdao.main/src/openmdao/main/systems.py
+++ b/openmdao.main/src/openmdao/main/systems.py
@@ -1807,7 +1807,7 @@ class OpaqueSystem(SimpleSystem):
         full = get_full_nodeset(scope, nodes)
         int_nodes = ograph.internal_nodes(full, shared=False)
         shared_int_nodes = ograph.internal_nodes(full, shared=True)
-        ograph.add_node(tuple(nodes), comp='opaque')
+        #ograph.add_node(tuple(nodes), comp='opaque')
         collapse_nodes(ograph, tuple(nodes), int_nodes)
 
         super(OpaqueSystem, self).__init__(scope, ograph, tuple(nodes))
@@ -1968,7 +1968,7 @@ class OpaqueSystem(SimpleSystem):
         self._inner_system.set_complex_step(complex_step)
 
     def set_ordering(self, ordering, opaque_map):
-        self._inner_system.set_ordering(ordering, opaque_map)
+        self._inner_system.set_ordering(ordering, {})
 
     def get_req_cpus(self):
         return self._inner_system.get_req_cpus()
@@ -2257,7 +2257,9 @@ def partition_subsystems(scope, graph, cgraph):
                     parallel_group.append(brnodes[0])
 
             for branch in parallel_group:
-                if isinstance(branch, tuple):
+                if 'system' in gcopy.node.get(branch,()):
+                    gcopy.remove_node(branch)
+                else: # multiple nodes
                     branch = tuple(branch)
                     to_remove.extend(branch)
                     subg = cgraph.subgraph(branch)
@@ -2266,8 +2268,6 @@ def partition_subsystems(scope, graph, cgraph):
                     collapse_to_system_node(cgraph, system, branch)
 
                     gcopy.remove_nodes_from(branch)
-                else: # single comp system
-                    gcopy.remove_node(branch)
 
             parallel_group = tuple(sorted(parallel_group))
             to_remove.extend(parallel_group)

--- a/openmdao.main/src/openmdao/main/test/test_system.py
+++ b/openmdao.main/src/openmdao/main/test/test_system.py
@@ -113,6 +113,22 @@ class TestcaseParaboloid(unittest.TestCase):
         # See if model gets the right answer
         self.assertEqual(top.f_xy, 93.)
 
+    def test_find_system(self):
+        top = self.top
+
+        top.driver.add_parameter('comp.x', low=-1000, high=1000)
+        top.driver.add_parameter('comp.y', low=-1000, high=1000)
+        top.driver.add_objective('comp.f_xy')
+        top.comp.x = 3
+        top.comp.y = 5
+
+        top.run()
+        
+        sys = top._system.find_system('comp')
+        self.assertTrue(sys.name == 'comp')
+        sys = top._system.find_system("('_pseudo_0', 'comp', 'comp.x', 'comp.y')")
+        self.assertTrue(sys.name == "('_pseudo_0', 'comp', 'comp.x', 'comp.y')")
+
 
 class ABCDArrayComp(Component):
     delay = Float(0.01, iotype='in')

--- a/openmdao.main/src/openmdao/main/vecwrapper.py
+++ b/openmdao.main/src/openmdao/main/vecwrapper.py
@@ -509,20 +509,20 @@ class DataTransfer(object):
                                             #destvec.name.rsplit('.',1)[0],
                                             #list(self.scatter_conns),
                                             #src[self.scatter.dest_idxs if addv else self.scatter.src_idxs])
-            print destvec.name
+            #print destvec.name
             #print self.scatter_conns
             #print srcvec.keys(), '-->'
             #print '-->', destvec.keys()
-            print "Before", srcvec.array, destvec.array
-            print "Before: %s" % str(system.name)
+            #print "Before", srcvec.array, destvec.array
+            #print "Before: %s" % str(system.name)
             #srcvec.dump()
-            print ''
+            #print ''
             #destvec.dump()
             self.scatter.scatter(src, dest, addv=addv, mode=mode)
-            print "After", srcvec.array, destvec.array
+            #print "After", srcvec.array, destvec.array
             #print "After:"
             #destvec.dump()
-            print '.'
+            #print '.'
 
 
         if destvec.name.endswith('.p') and self.noflat_vars:

--- a/openmdao.main/src/openmdao/main/vecwrapper.py
+++ b/openmdao.main/src/openmdao/main/vecwrapper.py
@@ -509,20 +509,20 @@ class DataTransfer(object):
                                             #destvec.name.rsplit('.',1)[0],
                                             #list(self.scatter_conns),
                                             #src[self.scatter.dest_idxs if addv else self.scatter.src_idxs])
-            #print destvec.name
+            print destvec.name
             #print self.scatter_conns
             #print srcvec.keys(), '-->'
             #print '-->', destvec.keys()
-            #print "Before", srcvec.array, destvec.array
-            #print "Before: %s" % str(system.name)
+            print "Before", srcvec.array, destvec.array
+            print "Before: %s" % str(system.name)
             #srcvec.dump()
-            #print ''
+            print ''
             #destvec.dump()
             self.scatter.scatter(src, dest, addv=addv, mode=mode)
-            #print "After", srcvec.array, destvec.array
+            print "After", srcvec.array, destvec.array
             #print "After:"
             #destvec.dump()
-            #print '.'
+            print '.'
 
 
         if destvec.name.endswith('.p') and self.noflat_vars:

--- a/openmdao.main/src/openmdao/main/workflow.py
+++ b/openmdao.main/src/openmdao/main/workflow.py
@@ -872,6 +872,7 @@ class Workflow(object):
                 reduced.add_node(gtup, comp=True)
                 collapse_nodes(reduced, gtup, reduced.internal_nodes(gtup))
                 reduced.node[gtup]['comp'] = True
+                reduced.node[gtup]['system'] = system
                 for c in gtup:
                     opaque_map[c] = gtup
 


### PR DESCRIPTION
1. Some more complicated graph topologies added to the MPI tests.
2. Adjoint derivative scatter fixed to work in diverge-converge cases
3. Newton solver modified to work on parallel systems
4. Some fixes so that full-model finite difference works on systems with parallel subsystems.
5. Some error messages and bugs fixed for parallel system setup.
6. Test added for Linear Gauss Seidel on a parallel system. This test fails currently.
7. Test added for differentiating parallel systems when a component has no derivatives. This test fails currently.