### PR TITLE
Added capability to print out residuals during linear and nonlinear solver convergence

### DIFF
--- a/openmdao.lib/src/openmdao/lib/casehandlers/test/jsonrecorder.json
+++ b/openmdao.lib/src/openmdao/lib/casehandlers/test/jsonrecorder.json
@@ -1,5 +1,5 @@
 {
-"__length_1": 17210
+"__length_1": 17492
 , "simulation_info": {
     "OpenMDAO_Version": "0.10.3.2", 
     "comp_graph": "{\"directed\": true, \"graph\": [], \"nodes\": [{\"comp\": true, \"id\": \"comp2\"}, {\"comp\": true, \"pseudo\": \"objective\", \"id\": \"_pseudo_1\"}, {\"comp\": true, \"id\": \"comp1\"}, {\"comp\": true, \"driver\": true, \"id\": \"driver\"}, {\"comp\": true, \"pseudo\": \"objective\", \"id\": \"_pseudo_0\"}], \"links\": [{\"source\": 0, \"target\": 1}, {\"source\": 2, \"target\": 0}, {\"source\": 2, \"target\": 4}], \"multigraph\": false}", 
@@ -48,6 +48,7 @@
         "driver.gradient_options.fd_step": 1e-06, 
         "driver.gradient_options.fd_step_type": "absolute", 
         "driver.gradient_options.force_fd": false, 
+        "driver.gradient_options.iprint": 0, 
         "driver.gradient_options.lin_solver": "scipy_gmres", 
         "driver.gradient_options.maxiter": 100, 
         "driver.gradient_options.rtol": 1e-09, 
@@ -75,7 +76,7 @@
     }, 
     "graph": "{\"directed\": true, \"graph\": [[\"title\", \"unknown\"]], \"nodes\": [{\"short\": \"ignore_egg_requirements\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.ignore_egg_requirements\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.ignore_egg_requirements\"}, {\"short\": \"in0\", \"color_idx\": 1, \"title\": \"{}\", \"full\": \"_pseudo_1.in0\", \"var\": true, \"iotype\": \"in\", \"id\": \"_pseudo_1.in0\"}, {\"short\": \"data\", \"color_idx\": 2, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"comp1.data\", \"var\": true, \"iotype\": \"in\", \"id\": \"comp1.data\"}, {\"short\": \"comp2\", \"color_idx\": 0, \"title\": \"{}\", \"comp\": true, \"full\": \"comp2\", \"id\": \"comp2\"}, {\"short\": \"_pseudo_1\", \"color_idx\": 1, \"title\": \"{}\", \"comp\": true, \"pseudo\": \"objective\", \"full\": \"_pseudo_1\", \"id\": \"_pseudo_1\"}, {\"short\": \"comp1\", \"color_idx\": 2, \"title\": \"{}\", \"comp\": true, \"full\": \"comp1\", \"id\": \"comp1\"}, {\"short\": \"in0\", \"color_idx\": 4, \"title\": \"{}\", \"full\": \"_pseudo_0.in0\", \"var\": true, \"iotype\": \"in\", \"id\": \"_pseudo_0.in0\"}, {\"short\": \"reload_model\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.reload_model\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.reload_model\"}, {\"short\": \"extra_resources\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.extra_resources\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.extra_resources\"}, {\"short\": \"case_inputs\", \"color_idx\": 3, \"deriv_ignore\": true, \"title\": \"{'deriv_ignore': True, 'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.case_inputs\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.case_inputs\"}, {\"short\": \"z\", \"color_idx\": 2, \"title\": \"{}\", \"full\": \"comp1.z\", \"var\": true, \"iotype\": \"out\", \"id\": \"comp1.z\"}, {\"short\": \"y\", \"color_idx\": 2, \"title\": \"{}\", \"full\": \"comp1.y\", \"var\": true, \"iotype\": \"in\", \"id\": \"comp1.y\"}, {\"short\": \"x\", \"color_idx\": 2, \"title\": \"{}\", \"full\": \"comp1.x\", \"var\": true, \"iotype\": \"in\", \"id\": \"comp1.x\"}, {\"short\": \"driver\", \"color_idx\": 3, \"title\": \"{'driver': True}\", \"comp\": true, \"driver\": true, \"full\": \"driver\", \"id\": \"driver\"}, {\"short\": \"x\", \"color_idx\": 0, \"title\": \"{}\", \"full\": \"comp2.x\", \"var\": true, \"iotype\": \"in\", \"id\": \"comp2.x\"}, {\"short\": \"z\", \"color_idx\": 0, \"title\": \"{}\", \"full\": \"comp2.z\", \"var\": true, \"iotype\": \"out\", \"id\": \"comp2.z\"}, {\"short\": \"sequential\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.sequential\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.sequential\"}, {\"short\": \"out0\", \"color_idx\": 1, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"_pseudo_1.out0\", \"var\": true, \"iotype\": \"out\", \"id\": \"_pseudo_1.out0\"}, {\"short\": \"error_policy\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.error_policy\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.error_policy\"}, {\"short\": \"_pseudo_0\", \"color_idx\": 4, \"title\": \"{}\", \"comp\": true, \"pseudo\": \"objective\", \"full\": \"_pseudo_0\", \"id\": \"_pseudo_0\"}, {\"short\": \"out0\", \"color_idx\": 4, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"_pseudo_0.out0\", \"var\": true, \"iotype\": \"out\", \"id\": \"_pseudo_0.out0\"}, {\"short\": \"case_outputs\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.case_outputs\", \"var\": true, \"iotype\": \"out\", \"id\": \"driver.case_outputs\"}, {\"short\": \"max_retries\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.max_retries\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.max_retries\"}], \"links\": [{\"source\": 0, \"target\": 13}, {\"source\": 1, \"target\": 4}, {\"drv_conn\": \"driver\", \"target\": 13, \"source\": 17}, {\"source\": 2, \"target\": 5}, {\"source\": 3, \"target\": 15}, {\"source\": 5, \"target\": 10}, {\"source\": 6, \"target\": 19}, {\"source\": 7, \"target\": 13}, {\"source\": 8, \"target\": 13}, {\"source\": 18, \"target\": 13}, {\"source\": 9, \"target\": 13}, {\"source\": 10, \"target\": 6, \"conn\": true}, {\"source\": 10, \"target\": 14, \"conn\": true}, {\"source\": 11, \"target\": 5}, {\"source\": 12, \"target\": 5}, {\"drv_conn\": \"driver\", \"target\": 13, \"source\": 20}, {\"source\": 14, \"target\": 3}, {\"source\": 13, \"target\": 21}, {\"drv_conn\": \"driver\", \"target\": 11, \"source\": 13}, {\"drv_conn\": \"driver\", \"target\": 12, \"source\": 13}, {\"source\": 15, \"target\": 1, \"conn\": true}, {\"source\": 4, \"target\": 17}, {\"source\": 19, \"target\": 20}, {\"source\": 16, \"target\": 13}, {\"source\": 22, \"target\": 13}], \"multigraph\": false}", 
     "name": "", 
-    "uuid": "d28fc07c-a23c-11e4-b184-3c970e57723f", 
+    "uuid": "520d1007-a656-11e4-889d-001f5b354a5c", 
     "variable_metadata": {
         "comp1.data": {
             "copy": "deep", 
@@ -305,6 +306,15 @@
             "iotype": "in", 
             "vartypename": "Bool"
         }, 
+        "driver.gradient_options.iprint": {
+            "assumed_default": false, 
+            "iotype": "in", 
+            "values": [
+                0, 
+                1
+            ], 
+            "vartypename": "Enum"
+        }, 
         "driver.gradient_options.lin_solver": {
             "assumed_default": false, 
             "iotype": "in", 
@@ -388,9 +398,9 @@
         }
     }
 }
-, "__length_2": 572
+, "__length_2": 567
 , "driver_info_1": {
-    "_id": 139760223212848, 
+    "_id": 4541033936, 
     "name": "driver", 
     "parameters": [
         "comp1.y", 
@@ -416,11 +426,11 @@
         "comp2.z"
     ]
 }
-, "__length_3": 698
+, "__length_3": 693
 , "iteration_case_1": {
-    "_driver_id": 139760223212848, 
-    "_id": "d290d5ab-a23c-11e4-800b-3c970e57723f", 
-    "_parent_id": "d28fc07c-a23c-11e4-b184-3c970e57723f", 
+    "_driver_id": 4541033936, 
+    "_id": "520de5f8-a656-11e4-800b-001f5b354a5c", 
+    "_parent_id": "520d1007-a656-11e4-889d-001f5b354a5c", 
     "data": {
         "_pseudo_0.out0": 0.0, 
         "_pseudo_1.out0": 1.0, 
@@ -438,13 +448,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.242609
+    "timestamp": 1422385040.201602
 }
-, "__length_4": 698
+, "__length_4": 693
 , "iteration_case_2": {
-    "_driver_id": 139760223212848, 
-    "_id": "d2913b59-a23c-11e4-800c-3c970e57723f", 
-    "_parent_id": "d28fc07c-a23c-11e4-b184-3c970e57723f", 
+    "_driver_id": 4541033936, 
+    "_id": "520e30d1-a656-11e4-800c-001f5b354a5c", 
+    "_parent_id": "520d1007-a656-11e4-889d-001f5b354a5c", 
     "data": {
         "_pseudo_0.out0": 3.0, 
         "_pseudo_1.out0": 4.0, 
@@ -462,13 +472,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.243926
+    "timestamp": 1422385040.202522
 }
-, "__length_5": 698
+, "__length_5": 692
 , "iteration_case_3": {
-    "_driver_id": 139760223212848, 
-    "_id": "d2916ddc-a23c-11e4-800d-3c970e57723f", 
-    "_parent_id": "d28fc07c-a23c-11e4-b184-3c970e57723f", 
+    "_driver_id": 4541033936, 
+    "_id": "520e548f-a656-11e4-800d-001f5b354a5c", 
+    "_parent_id": "520d1007-a656-11e4-889d-001f5b354a5c", 
     "data": {
         "_pseudo_0.out0": 6.0, 
         "_pseudo_1.out0": 7.0, 
@@ -486,13 +496,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.245138
+    "timestamp": 1422385040.20343
 }
-, "__length_6": 700
+, "__length_6": 695
 , "iteration_case_4": {
-    "_driver_id": 139760223212848, 
-    "_id": "d2919cc5-a23c-11e4-800e-3c970e57723f", 
-    "_parent_id": "d28fc07c-a23c-11e4-b184-3c970e57723f", 
+    "_driver_id": 4541033936, 
+    "_id": "520e7811-a656-11e4-800e-001f5b354a5c", 
+    "_parent_id": "520d1007-a656-11e4-889d-001f5b354a5c", 
     "data": {
         "_pseudo_0.out0": 9.0, 
         "_pseudo_1.out0": 10.0, 
@@ -510,13 +520,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.246317
+    "timestamp": 1422385040.204426
 }
-, "__length_7": 702
+, "__length_7": 697
 , "iteration_case_5": {
-    "_driver_id": 139760223212848, 
-    "_id": "d291cad4-a23c-11e4-800f-3c970e57723f", 
-    "_parent_id": "d28fc07c-a23c-11e4-b184-3c970e57723f", 
+    "_driver_id": 4541033936, 
+    "_id": "520e9f05-a656-11e4-800f-001f5b354a5c", 
+    "_parent_id": "520d1007-a656-11e4-889d-001f5b354a5c", 
     "data": {
         "_pseudo_0.out0": 12.0, 
         "_pseudo_1.out0": 13.0, 
@@ -534,13 +544,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.247535
+    "timestamp": 1422385040.205337
 }
-, "__length_8": 703
+, "__length_8": 697
 , "iteration_case_6": {
-    "_driver_id": 139760223212848, 
-    "_id": "d291faa3-a23c-11e4-8010-3c970e57723f", 
-    "_parent_id": "d28fc07c-a23c-11e4-b184-3c970e57723f", 
+    "_driver_id": 4541033936, 
+    "_id": "520ec240-a656-11e4-8010-001f5b354a5c", 
+    "_parent_id": "520d1007-a656-11e4-889d-001f5b354a5c", 
     "data": {
         "_pseudo_0.out0": 15.0, 
         "_pseudo_1.out0": 16.0, 
@@ -558,13 +568,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.248727
+    "timestamp": 1422385040.20624
 }
-, "__length_9": 703
+, "__length_9": 698
 , "iteration_case_7": {
-    "_driver_id": 139760223212848, 
-    "_id": "d2922921-a23c-11e4-8011-3c970e57723f", 
-    "_parent_id": "d28fc07c-a23c-11e4-b184-3c970e57723f", 
+    "_driver_id": 4541033936, 
+    "_id": "520ee585-a656-11e4-8011-001f5b354a5c", 
+    "_parent_id": "520d1007-a656-11e4-889d-001f5b354a5c", 
     "data": {
         "_pseudo_0.out0": 18.0, 
         "_pseudo_1.out0": 19.0, 
@@ -582,13 +592,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.249903
+    "timestamp": 1422385040.207144
 }
-, "__length_10": 703
+, "__length_10": 698
 , "iteration_case_8": {
-    "_driver_id": 139760223212848, 
-    "_id": "d29256de-a23c-11e4-8012-3c970e57723f", 
-    "_parent_id": "d28fc07c-a23c-11e4-b184-3c970e57723f", 
+    "_driver_id": 4541033936, 
+    "_id": "520f08d4-a656-11e4-8012-001f5b354a5c", 
+    "_parent_id": "520d1007-a656-11e4-889d-001f5b354a5c", 
     "data": {
         "_pseudo_0.out0": 21.0, 
         "_pseudo_1.out0": 22.0, 
@@ -606,13 +616,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.251096
+    "timestamp": 1422385040.208052
 }
-, "__length_11": 703
+, "__length_11": 698
 , "iteration_case_9": {
-    "_driver_id": 139760223212848, 
-    "_id": "d2928761-a23c-11e4-8013-3c970e57723f", 
-    "_parent_id": "d28fc07c-a23c-11e4-b184-3c970e57723f", 
+    "_driver_id": 4541033936, 
+    "_id": "520f2cbd-a656-11e4-8013-001f5b354a5c", 
+    "_parent_id": "520d1007-a656-11e4-889d-001f5b354a5c", 
     "data": {
         "_pseudo_0.out0": 24.0, 
         "_pseudo_1.out0": 25.0, 
@@ -630,13 +640,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.252371
+    "timestamp": 1422385040.208965
 }
-, "__length_12": 708
+, "__length_12": 703
 , "iteration_case_10": {
-    "_driver_id": 139760223212848, 
-    "_id": "d292b7ab-a23c-11e4-8014-3c970e57723f", 
-    "_parent_id": "d28fc07c-a23c-11e4-b184-3c970e57723f", 
+    "_driver_id": 4541033936, 
+    "_id": "520f5078-a656-11e4-8014-001f5b354a5c", 
+    "_parent_id": "520d1007-a656-11e4-889d-001f5b354a5c", 
     "data": {
         "_pseudo_0.out0": 27.0, 
         "_pseudo_1.out0": 28.0, 
@@ -654,6 +664,6 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.253585
+    "timestamp": 1422385040.209884
 }
 }

--- a/openmdao.lib/src/openmdao/lib/casehandlers/test/jsonrecorder_norun.json
+++ b/openmdao.lib/src/openmdao/lib/casehandlers/test/jsonrecorder_norun.json
@@ -1,5 +1,5 @@
 {
-"__length_1": 17210
+"__length_1": 17492
 , "simulation_info": {
     "OpenMDAO_Version": "0.10.3.2", 
     "comp_graph": "{\"directed\": true, \"graph\": [], \"nodes\": [{\"comp\": true, \"id\": \"comp2\"}, {\"comp\": true, \"pseudo\": \"objective\", \"id\": \"_pseudo_1\"}, {\"comp\": true, \"id\": \"comp1\"}, {\"comp\": true, \"driver\": true, \"id\": \"driver\"}, {\"comp\": true, \"pseudo\": \"objective\", \"id\": \"_pseudo_0\"}], \"links\": [{\"source\": 0, \"target\": 1}, {\"source\": 2, \"target\": 0}, {\"source\": 2, \"target\": 4}], \"multigraph\": false}", 
@@ -48,6 +48,7 @@
         "driver.gradient_options.fd_step": 1e-06, 
         "driver.gradient_options.fd_step_type": "absolute", 
         "driver.gradient_options.force_fd": false, 
+        "driver.gradient_options.iprint": 0, 
         "driver.gradient_options.lin_solver": "scipy_gmres", 
         "driver.gradient_options.maxiter": 100, 
         "driver.gradient_options.rtol": 1e-09, 
@@ -75,7 +76,7 @@
     }, 
     "graph": "{\"directed\": true, \"graph\": [[\"title\", \"unknown\"]], \"nodes\": [{\"short\": \"ignore_egg_requirements\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.ignore_egg_requirements\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.ignore_egg_requirements\"}, {\"short\": \"in0\", \"color_idx\": 1, \"title\": \"{}\", \"full\": \"_pseudo_1.in0\", \"var\": true, \"iotype\": \"in\", \"id\": \"_pseudo_1.in0\"}, {\"short\": \"data\", \"color_idx\": 2, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"comp1.data\", \"var\": true, \"iotype\": \"in\", \"id\": \"comp1.data\"}, {\"short\": \"comp2\", \"color_idx\": 0, \"title\": \"{}\", \"comp\": true, \"full\": \"comp2\", \"id\": \"comp2\"}, {\"short\": \"_pseudo_1\", \"color_idx\": 1, \"title\": \"{}\", \"comp\": true, \"pseudo\": \"objective\", \"full\": \"_pseudo_1\", \"id\": \"_pseudo_1\"}, {\"short\": \"comp1\", \"color_idx\": 2, \"title\": \"{}\", \"comp\": true, \"full\": \"comp1\", \"id\": \"comp1\"}, {\"short\": \"in0\", \"color_idx\": 4, \"title\": \"{}\", \"full\": \"_pseudo_0.in0\", \"var\": true, \"iotype\": \"in\", \"id\": \"_pseudo_0.in0\"}, {\"short\": \"reload_model\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.reload_model\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.reload_model\"}, {\"short\": \"extra_resources\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.extra_resources\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.extra_resources\"}, {\"short\": \"case_inputs\", \"color_idx\": 3, \"deriv_ignore\": true, \"title\": \"{'deriv_ignore': True, 'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.case_inputs\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.case_inputs\"}, {\"short\": \"z\", \"color_idx\": 2, \"title\": \"{}\", \"full\": \"comp1.z\", \"var\": true, \"iotype\": \"out\", \"id\": \"comp1.z\"}, {\"short\": \"y\", \"color_idx\": 2, \"title\": \"{}\", \"full\": \"comp1.y\", \"var\": true, \"iotype\": \"in\", \"id\": \"comp1.y\"}, {\"short\": \"x\", \"color_idx\": 2, \"title\": \"{}\", \"full\": \"comp1.x\", \"var\": true, \"iotype\": \"in\", \"id\": \"comp1.x\"}, {\"short\": \"driver\", \"color_idx\": 3, \"title\": \"{'driver': True}\", \"comp\": true, \"driver\": true, \"full\": \"driver\", \"id\": \"driver\"}, {\"short\": \"x\", \"color_idx\": 0, \"title\": \"{}\", \"full\": \"comp2.x\", \"var\": true, \"iotype\": \"in\", \"id\": \"comp2.x\"}, {\"short\": \"z\", \"color_idx\": 0, \"title\": \"{}\", \"full\": \"comp2.z\", \"var\": true, \"iotype\": \"out\", \"id\": \"comp2.z\"}, {\"short\": \"sequential\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.sequential\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.sequential\"}, {\"short\": \"out0\", \"color_idx\": 1, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"_pseudo_1.out0\", \"var\": true, \"iotype\": \"out\", \"id\": \"_pseudo_1.out0\"}, {\"short\": \"error_policy\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.error_policy\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.error_policy\"}, {\"short\": \"_pseudo_0\", \"color_idx\": 4, \"title\": \"{}\", \"comp\": true, \"pseudo\": \"objective\", \"full\": \"_pseudo_0\", \"id\": \"_pseudo_0\"}, {\"short\": \"out0\", \"color_idx\": 4, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"_pseudo_0.out0\", \"var\": true, \"iotype\": \"out\", \"id\": \"_pseudo_0.out0\"}, {\"short\": \"case_outputs\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.case_outputs\", \"var\": true, \"iotype\": \"out\", \"id\": \"driver.case_outputs\"}, {\"short\": \"max_retries\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.max_retries\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.max_retries\"}], \"links\": [{\"source\": 0, \"target\": 13}, {\"source\": 1, \"target\": 4}, {\"drv_conn\": \"driver\", \"target\": 13, \"source\": 17}, {\"source\": 2, \"target\": 5}, {\"source\": 3, \"target\": 15}, {\"source\": 5, \"target\": 10}, {\"source\": 6, \"target\": 19}, {\"source\": 7, \"target\": 13}, {\"source\": 8, \"target\": 13}, {\"source\": 18, \"target\": 13}, {\"source\": 9, \"target\": 13}, {\"source\": 10, \"target\": 6, \"conn\": true}, {\"source\": 10, \"target\": 14, \"conn\": true}, {\"source\": 11, \"target\": 5}, {\"source\": 12, \"target\": 5}, {\"drv_conn\": \"driver\", \"target\": 13, \"source\": 20}, {\"source\": 14, \"target\": 3}, {\"source\": 13, \"target\": 21}, {\"drv_conn\": \"driver\", \"target\": 11, \"source\": 13}, {\"drv_conn\": \"driver\", \"target\": 12, \"source\": 13}, {\"source\": 15, \"target\": 1, \"conn\": true}, {\"source\": 4, \"target\": 17}, {\"source\": 19, \"target\": 20}, {\"source\": 16, \"target\": 13}, {\"source\": 22, \"target\": 13}], \"multigraph\": false}", 
     "name": "", 
-    "uuid": "d2940a74-a23c-11e4-ad32-3c970e57723f", 
+    "uuid": "86be0582-a656-11e4-aa13-001f5b354a5c", 
     "variable_metadata": {
         "comp1.data": {
             "copy": "deep", 
@@ -305,6 +306,15 @@
             "iotype": "in", 
             "vartypename": "Bool"
         }, 
+        "driver.gradient_options.iprint": {
+            "assumed_default": false, 
+            "iotype": "in", 
+            "values": [
+                0, 
+                1
+            ], 
+            "vartypename": "Enum"
+        }, 
         "driver.gradient_options.lin_solver": {
             "assumed_default": false, 
             "iotype": "in", 
@@ -388,9 +398,9 @@
         }
     }
 }
-, "__length_2": 572
+, "__length_2": 567
 , "driver_info_1": {
-    "_id": 139760223212944, 
+    "_id": 4318870992, 
     "name": "driver", 
     "parameters": [
         "comp1.y", 

--- a/openmdao.lib/src/openmdao/lib/casehandlers/test/multiobj.json
+++ b/openmdao.lib/src/openmdao/lib/casehandlers/test/multiobj.json
@@ -1,5 +1,5 @@
 {
-"__length_1": 14466
+"__length_1": 14748
 , "simulation_info": {
     "OpenMDAO_Version": "0.10.3.2", 
     "comp_graph": "{\"directed\": true, \"graph\": [], \"nodes\": [{\"comp\": true, \"id\": \"comp2\"}, {\"comp\": true, \"pseudo\": \"objective\", \"id\": \"_pseudo_3\"}, {\"comp\": true, \"id\": \"comp1\"}, {\"comp\": true, \"driver\": true, \"id\": \"driver\"}, {\"comp\": true, \"pseudo\": \"objective\", \"id\": \"_pseudo_2\"}], \"links\": [{\"source\": 0, \"target\": 1}, {\"source\": 2, \"target\": 0}, {\"source\": 2, \"target\": 4}], \"multigraph\": false}", 
@@ -23,6 +23,7 @@
         "driver.gradient_options.fd_step": 1e-06, 
         "driver.gradient_options.fd_step_type": "absolute", 
         "driver.gradient_options.force_fd": false, 
+        "driver.gradient_options.iprint": 0, 
         "driver.gradient_options.lin_solver": "scipy_gmres", 
         "driver.gradient_options.maxiter": 100, 
         "driver.gradient_options.rtol": 1e-09, 
@@ -46,7 +47,7 @@
     }, 
     "graph": "{\"directed\": true, \"graph\": [[\"title\", \"unknown\"]], \"nodes\": [{\"short\": \"out0\", \"color_idx\": 1, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"_pseudo_3.out0\", \"var\": true, \"iotype\": \"out\", \"id\": \"_pseudo_3.out0\"}, {\"short\": \"data\", \"color_idx\": 2, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"comp1.data\", \"var\": true, \"iotype\": \"in\", \"id\": \"comp1.data\"}, {\"short\": \"comp2\", \"color_idx\": 0, \"title\": \"{}\", \"comp\": true, \"full\": \"comp2\", \"id\": \"comp2\"}, {\"short\": \"comp1\", \"color_idx\": 2, \"title\": \"{}\", \"comp\": true, \"full\": \"comp1\", \"id\": \"comp1\"}, {\"short\": \"F\", \"color_idx\": 3, \"title\": \"{}\", \"full\": \"driver.F\", \"var\": true, \"iotype\": \"out\", \"id\": \"driver.F\"}, {\"short\": \"G\", \"color_idx\": 3, \"title\": \"{}\", \"full\": \"driver.G\", \"var\": true, \"iotype\": \"out\", \"id\": \"driver.G\"}, {\"short\": \"dF_names\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.dF_names\", \"var\": true, \"iotype\": \"out\", \"id\": \"driver.dF_names\"}, {\"short\": \"dx_names\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.dx_names\", \"var\": true, \"iotype\": \"out\", \"id\": \"driver.dx_names\"}, {\"short\": \"z\", \"color_idx\": 2, \"title\": \"{}\", \"full\": \"comp1.z\", \"var\": true, \"iotype\": \"out\", \"id\": \"comp1.z\"}, {\"short\": \"y\", \"color_idx\": 2, \"title\": \"{}\", \"full\": \"comp1.y\", \"var\": true, \"iotype\": \"in\", \"id\": \"comp1.y\"}, {\"short\": \"x\", \"color_idx\": 2, \"title\": \"{}\", \"full\": \"comp1.x\", \"var\": true, \"iotype\": \"in\", \"id\": \"comp1.x\"}, {\"short\": \"x\", \"color_idx\": 3, \"title\": \"{}\", \"full\": \"driver.x\", \"var\": true, \"iotype\": \"out\", \"id\": \"driver.x\"}, {\"short\": \"in0\", \"color_idx\": 1, \"title\": \"{}\", \"full\": \"_pseudo_3.in0\", \"var\": true, \"iotype\": \"in\", \"id\": \"_pseudo_3.in0\"}, {\"short\": \"driver\", \"color_idx\": 3, \"title\": \"{'driver': True}\", \"comp\": true, \"driver\": true, \"full\": \"driver\", \"id\": \"driver\"}, {\"short\": \"x\", \"color_idx\": 0, \"title\": \"{}\", \"full\": \"comp2.x\", \"var\": true, \"iotype\": \"in\", \"id\": \"comp2.x\"}, {\"short\": \"z\", \"color_idx\": 0, \"title\": \"{}\", \"full\": \"comp2.z\", \"var\": true, \"iotype\": \"out\", \"id\": \"comp2.z\"}, {\"short\": \"dG\", \"color_idx\": 3, \"title\": \"{}\", \"full\": \"driver.dG\", \"var\": true, \"iotype\": \"out\", \"id\": \"driver.dG\"}, {\"short\": \"dF\", \"color_idx\": 3, \"title\": \"{}\", \"full\": \"driver.dF\", \"var\": true, \"iotype\": \"out\", \"id\": \"driver.dF\"}, {\"short\": \"in0\", \"color_idx\": 4, \"title\": \"{}\", \"full\": \"_pseudo_2.in0\", \"var\": true, \"iotype\": \"in\", \"id\": \"_pseudo_2.in0\"}, {\"short\": \"_pseudo_3\", \"color_idx\": 1, \"title\": \"{}\", \"comp\": true, \"pseudo\": \"objective\", \"full\": \"_pseudo_3\", \"id\": \"_pseudo_3\"}, {\"short\": \"_pseudo_2\", \"color_idx\": 4, \"title\": \"{}\", \"comp\": true, \"pseudo\": \"objective\", \"full\": \"_pseudo_2\", \"id\": \"_pseudo_2\"}, {\"short\": \"out0\", \"color_idx\": 4, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"_pseudo_2.out0\", \"var\": true, \"iotype\": \"out\", \"id\": \"_pseudo_2.out0\"}, {\"short\": \"dG_names\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.dG_names\", \"var\": true, \"iotype\": \"out\", \"id\": \"driver.dG_names\"}], \"links\": [{\"drv_conn\": \"driver\", \"target\": 13, \"source\": 0}, {\"source\": 1, \"target\": 3}, {\"source\": 2, \"target\": 15}, {\"source\": 3, \"target\": 8}, {\"source\": 19, \"target\": 0}, {\"source\": 8, \"target\": 18, \"conn\": true}, {\"source\": 8, \"target\": 14, \"conn\": true}, {\"source\": 9, \"target\": 3}, {\"source\": 10, \"target\": 3}, {\"source\": 12, \"target\": 19}, {\"source\": 14, \"target\": 2}, {\"source\": 13, \"target\": 11}, {\"source\": 13, \"target\": 6}, {\"source\": 13, \"target\": 22}, {\"source\": 13, \"target\": 7}, {\"source\": 13, \"target\": 16}, {\"source\": 13, \"target\": 17}, {\"drv_conn\": \"driver\", \"target\": 10, \"source\": 13}, {\"source\": 13, \"target\": 4}, {\"source\": 13, \"target\": 5}, {\"source\": 15, \"target\": 12, \"conn\": true}, {\"source\": 18, \"target\": 20}, {\"source\": 20, \"target\": 21}, {\"drv_conn\": \"driver\", \"target\": 13, \"source\": 21}], \"multigraph\": false}", 
     "name": "", 
-    "uuid": "d29599ac-a23c-11e4-bc39-3c970e57723f", 
+    "uuid": "b5eb3e38-a656-11e4-89a7-001f5b354a5c", 
     "variable_metadata": {
         "comp1.data": {
             "copy": "deep", 
@@ -249,6 +250,15 @@
             "iotype": "in", 
             "vartypename": "Bool"
         }, 
+        "driver.gradient_options.iprint": {
+            "assumed_default": false, 
+            "iotype": "in", 
+            "values": [
+                0, 
+                1
+            ], 
+            "vartypename": "Enum"
+        }, 
         "driver.gradient_options.lin_solver": {
             "assumed_default": false, 
             "iotype": "in", 
@@ -308,9 +318,9 @@
         }
     }
 }
-, "__length_2": 589
+, "__length_2": 584
 , "driver_info_1": {
-    "_id": 139760223183216, 
+    "_id": 4435255120, 
     "eq_constraints": [], 
     "ineq_constraints": [], 
     "name": "driver", 
@@ -336,11 +346,11 @@
         "driver.workflow.itername"
     ]
 }
-, "__length_3": 665
+, "__length_3": 659
 , "iteration_case_1": {
-    "_driver_id": 139760223183216, 
-    "_id": "d2965a21-a23c-11e4-800b-3c970e57723f", 
-    "_parent_id": "d29599ac-a23c-11e4-bc39-3c970e57723f", 
+    "_driver_id": 4435255120, 
+    "_id": "b5ebddde-a656-11e4-800b-001f5b354a5c", 
+    "_parent_id": "b5eb3e38-a656-11e4-89a7-001f5b354a5c", 
     "data": {
         "_pseudo_2.out0": 0.0, 
         "_pseudo_3.out0": 1.0, 
@@ -357,6 +367,6 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.278603
+    "timestamp": 1422385207.75067
 }
 }

--- a/openmdao.lib/src/openmdao/lib/casehandlers/test/nested.json
+++ b/openmdao.lib/src/openmdao/lib/casehandlers/test/nested.json
@@ -1,5 +1,5 @@
 {
-"__length_1": 33379
+"__length_1": 34255
 , "simulation_info": {
     "OpenMDAO_Version": "0.10.3.2", 
     "comp_graph": "{\"directed\": true, \"graph\": [], \"nodes\": [{\"comp\": true, \"pseudo\": \"constraint\", \"id\": \"_pseudo_1\"}, {\"comp\": true, \"pseudo\": \"objective\", \"id\": \"_pseudo_0\"}, {\"comp\": true, \"id\": \"comp1\"}, {\"comp\": true, \"driver\": true, \"id\": \"driver\"}, {\"comp\": true, \"id\": \"asm2\"}], \"links\": [{\"source\": 2, \"target\": 0}, {\"source\": 2, \"target\": 4}, {\"source\": 4, \"target\": 1}], \"multigraph\": false}", 
@@ -19,6 +19,7 @@
         "asm2.asm3.driver.gradient_options.fd_step": 1e-06, 
         "asm2.asm3.driver.gradient_options.fd_step_type": "absolute", 
         "asm2.asm3.driver.gradient_options.force_fd": false, 
+        "asm2.asm3.driver.gradient_options.iprint": 0, 
         "asm2.asm3.driver.gradient_options.lin_solver": "scipy_gmres", 
         "asm2.asm3.driver.gradient_options.maxiter": 100, 
         "asm2.asm3.driver.gradient_options.rtol": 1e-09, 
@@ -48,6 +49,7 @@
         "asm2.driver.gradient_options.fd_step": 1e-06, 
         "asm2.driver.gradient_options.fd_step_type": "absolute", 
         "asm2.driver.gradient_options.force_fd": false, 
+        "asm2.driver.gradient_options.iprint": 0, 
         "asm2.driver.gradient_options.lin_solver": "scipy_gmres", 
         "asm2.driver.gradient_options.maxiter": 100, 
         "asm2.driver.gradient_options.rtol": 1e-09, 
@@ -78,6 +80,7 @@
         "driver.gradient_options.fd_step": 1e-06, 
         "driver.gradient_options.fd_step_type": "absolute", 
         "driver.gradient_options.force_fd": false, 
+        "driver.gradient_options.iprint": 0, 
         "driver.gradient_options.lin_solver": "scipy_gmres", 
         "driver.gradient_options.maxiter": 100, 
         "driver.gradient_options.rtol": 1e-09, 
@@ -121,7 +124,7 @@
     }, 
     "graph": "{\"directed\": true, \"graph\": [[\"title\", \"unknown\"]], \"nodes\": [{\"short\": \"in0\", \"color_idx\": 0, \"title\": \"{}\", \"full\": \"_pseudo_1.in0\", \"var\": true, \"iotype\": \"in\", \"id\": \"_pseudo_1.in0\"}, {\"short\": \"output_filename\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.output_filename\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.output_filename\"}, {\"short\": \"comp1\", \"color_idx\": 2, \"title\": \"{}\", \"comp\": true, \"full\": \"comp1\", \"id\": \"comp1\"}, {\"short\": \"in0\", \"color_idx\": 1, \"title\": \"{}\", \"full\": \"_pseudo_0.in0\", \"var\": true, \"iotype\": \"in\", \"id\": \"_pseudo_0.in0\"}, {\"short\": \"iprint\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.iprint\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.iprint\"}, {\"short\": \"z\", \"color_idx\": 2, \"title\": \"{}\", \"full\": \"comp1.z\", \"var\": true, \"iotype\": \"out\", \"id\": \"comp1.z\"}, {\"short\": \"y\", \"color_idx\": 2, \"title\": \"{}\", \"full\": \"comp1.y\", \"var\": true, \"iotype\": \"in\", \"id\": \"comp1.y\"}, {\"short\": \"x\", \"color_idx\": 2, \"title\": \"{}\", \"full\": \"comp1.x\", \"var\": true, \"iotype\": \"in\", \"id\": \"comp1.x\"}, {\"short\": \"accuracy\", \"color_idx\": 3, \"title\": \"{}\", \"full\": \"driver.accuracy\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.accuracy\"}, {\"short\": \"error_code\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.error_code\", \"var\": true, \"iotype\": \"out\", \"id\": \"driver.error_code\"}, {\"short\": \"driver\", \"color_idx\": 3, \"title\": \"{'driver': True}\", \"comp\": true, \"driver\": true, \"full\": \"driver\", \"id\": \"driver\"}, {\"short\": \"iout\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.iout\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.iout\"}, {\"short\": \"out0\", \"color_idx\": 0, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"_pseudo_1.out0\", \"var\": true, \"iotype\": \"out\", \"id\": \"_pseudo_1.out0\"}, {\"short\": \"_pseudo_1\", \"color_idx\": 0, \"title\": \"{}\", \"comp\": true, \"pseudo\": \"constraint\", \"full\": \"_pseudo_1\", \"id\": \"_pseudo_1\"}, {\"short\": \"_pseudo_0\", \"color_idx\": 1, \"title\": \"{}\", \"comp\": true, \"pseudo\": \"objective\", \"full\": \"_pseudo_0\", \"id\": \"_pseudo_0\"}, {\"short\": \"out0\", \"color_idx\": 1, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"_pseudo_0.out0\", \"var\": true, \"iotype\": \"out\", \"id\": \"_pseudo_0.out0\"}, {\"short\": \"asm2\", \"color_idx\": 4, \"title\": \"{}\", \"comp\": true, \"full\": \"asm2\", \"id\": \"asm2\"}, {\"short\": \"maxiter\", \"color_idx\": 3, \"title\": \"{'differentiable': False}\", \"differentiable\": false, \"full\": \"driver.maxiter\", \"var\": true, \"iotype\": \"in\", \"id\": \"driver.maxiter\"}, {\"short\": \"x\", \"color_idx\": 4, \"title\": \"{}\", \"full\": \"asm2.x\", \"var\": true, \"iotype\": \"in\", \"id\": \"asm2.x\"}, {\"short\": \"z\", \"color_idx\": 4, \"title\": \"{}\", \"full\": \"asm2.z\", \"var\": true, \"iotype\": \"out\", \"id\": \"asm2.z\"}], \"links\": [{\"source\": 0, \"target\": 13}, {\"source\": 1, \"target\": 10}, {\"drv_conn\": \"driver\", \"target\": 10, \"source\": 12}, {\"source\": 2, \"target\": 5}, {\"source\": 3, \"target\": 14}, {\"source\": 4, \"target\": 10}, {\"source\": 5, \"target\": 0, \"conn\": true}, {\"source\": 5, \"target\": 18, \"conn\": true}, {\"source\": 6, \"target\": 2}, {\"source\": 7, \"target\": 2}, {\"drv_conn\": \"driver\", \"target\": 10, \"source\": 15}, {\"source\": 8, \"target\": 10}, {\"drv_conn\": \"driver\", \"target\": 6, \"source\": 10}, {\"source\": 10, \"target\": 9}, {\"source\": 11, \"target\": 10}, {\"source\": 13, \"target\": 12}, {\"source\": 14, \"target\": 15}, {\"source\": 16, \"target\": 19}, {\"source\": 17, \"target\": 10}, {\"source\": 18, \"target\": 16}, {\"source\": 19, \"target\": 3, \"conn\": true}], \"multigraph\": false}", 
     "name": "", 
-    "uuid": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "uuid": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "variable_metadata": {
         "asm2.asm3.comp1.derivative_exec_count": {
             "assumed_default": false, 
@@ -277,6 +280,15 @@
             "assumed_default": false, 
             "iotype": "in", 
             "vartypename": "Bool"
+        }, 
+        "asm2.asm3.driver.gradient_options.iprint": {
+            "assumed_default": false, 
+            "iotype": "in", 
+            "values": [
+                0, 
+                1
+            ], 
+            "vartypename": "Enum"
         }, 
         "asm2.asm3.driver.gradient_options.lin_solver": {
             "assumed_default": false, 
@@ -545,6 +557,15 @@
             "iotype": "in", 
             "vartypename": "Bool"
         }, 
+        "asm2.driver.gradient_options.iprint": {
+            "assumed_default": false, 
+            "iotype": "in", 
+            "values": [
+                0, 
+                1
+            ], 
+            "vartypename": "Enum"
+        }, 
         "asm2.driver.gradient_options.lin_solver": {
             "assumed_default": false, 
             "iotype": "in", 
@@ -808,6 +829,15 @@
             "iotype": "in", 
             "vartypename": "Bool"
         }, 
+        "driver.gradient_options.iprint": {
+            "assumed_default": false, 
+            "iotype": "in", 
+            "values": [
+                0, 
+                1
+            ], 
+            "vartypename": "Enum"
+        }, 
         "driver.gradient_options.lin_solver": {
             "assumed_default": false, 
             "iotype": "in", 
@@ -900,9 +930,9 @@
         }
     }
 }
-, "__length_2": 491
+, "__length_2": 486
 , "driver_info_1": {
-    "_id": 139760222667504, 
+    "_id": 4552474992, 
     "eq_constraints": [], 
     "ineq_constraints": [
         "comp1.z >= 0"
@@ -925,9 +955,9 @@
         "driver.workflow.itername"
     ]
 }
-, "__length_3": 597
+, "__length_3": 592
 , "driver_info_2": {
-    "_id": 139760222667984, 
+    "_id": 4552475472, 
     "eq_constraints": [], 
     "ineq_constraints": [
         "comp1.z >= 0"
@@ -954,9 +984,9 @@
         "driver.workflow.itername"
     ]
 }
-, "__length_4": 592
+, "__length_4": 587
 , "driver_info_3": {
-    "_id": 139760222668464, 
+    "_id": 4552475952, 
     "eq_constraints": [], 
     "ineq_constraints": [
         "comp1.z >= 0"
@@ -983,11 +1013,11 @@
         "driver.workflow.itername"
     ]
 }
-, "__length_5": 636
+, "__length_5": 631
 , "iteration_case_1": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2a8318c-a23c-11e4-800d-3c970e57723f", 
-    "_parent_id": "d2a7db6b-a23c-11e4-800c-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b166d4-a656-11e4-800d-001f5b354a5c", 
+    "_parent_id": "d5b0ee00-a656-11e4-800c-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 0.0, 
         "asm2.asm3._pseudo_1.out0": -0.0, 
@@ -1000,13 +1030,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.394081
+    "timestamp": 1422385261.053957
 }
-, "__length_6": 636
+, "__length_6": 631
 , "iteration_case_2": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2a85bdc-a23c-11e4-800e-3c970e57723f", 
-    "_parent_id": "d2a7db6b-a23c-11e4-800c-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b19ccf-a656-11e4-800e-001f5b354a5c", 
+    "_parent_id": "d5b0ee00-a656-11e4-800c-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 0.0, 
         "asm2.asm3._pseudo_1.out0": -0.0, 
@@ -1019,13 +1049,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.394814
+    "timestamp": 1422385261.054854
 }
-, "__length_7": 742
+, "__length_7": 737
 , "iteration_case_3": {
-    "_driver_id": 139760222667984, 
-    "_id": "d2a7db6b-a23c-11e4-800c-3c970e57723f", 
-    "_parent_id": "d2a70051-a23c-11e4-800b-3c970e57723f", 
+    "_driver_id": 4552475472, 
+    "_id": "d5b0ee00-a656-11e4-800c-001f5b354a5c", 
+    "_parent_id": "d5b01373-a656-11e4-800b-001f5b354a5c", 
     "data": {
         "asm2._pseudo_0.out0": 0.0, 
         "asm2._pseudo_1.out0": -0.0, 
@@ -1042,13 +1072,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.397431
+    "timestamp": 1422385261.058105
 }
-, "__length_8": 636
+, "__length_8": 631
 , "iteration_case_4": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2a8eb73-a23c-11e4-8010-3c970e57723f", 
-    "_parent_id": "d2a8da8a-a23c-11e4-800f-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b25530-a656-11e4-8010-001f5b354a5c", 
+    "_parent_id": "d5b23d1e-a656-11e4-800f-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 0.0, 
         "asm2.asm3._pseudo_1.out0": -0.0, 
@@ -1061,13 +1091,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.398448
+    "timestamp": 1422385261.059569
 }
-, "__length_9": 636
+, "__length_9": 631
 , "iteration_case_5": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2a90140-a23c-11e4-8011-3c970e57723f", 
-    "_parent_id": "d2a8da8a-a23c-11e4-800f-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b274fa-a656-11e4-8011-001f5b354a5c", 
+    "_parent_id": "d5b23d1e-a656-11e4-800f-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 0.0, 
         "asm2.asm3._pseudo_1.out0": -0.0, 
@@ -1080,13 +1110,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.399011
+    "timestamp": 1422385261.060382
 }
-, "__length_10": 742
+, "__length_10": 737
 , "iteration_case_6": {
-    "_driver_id": 139760222667984, 
-    "_id": "d2a8da8a-a23c-11e4-800f-3c970e57723f", 
-    "_parent_id": "d2a70051-a23c-11e4-800b-3c970e57723f", 
+    "_driver_id": 4552475472, 
+    "_id": "d5b23d1e-a656-11e4-800f-001f5b354a5c", 
+    "_parent_id": "d5b01373-a656-11e4-800b-001f5b354a5c", 
     "data": {
         "asm2._pseudo_0.out0": 0.0, 
         "asm2._pseudo_1.out0": -0.0, 
@@ -1103,13 +1133,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.400628
+    "timestamp": 1422385261.062442
 }
-, "__length_11": 683
+, "__length_11": 678
 , "iteration_case_7": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2a96b26-a23c-11e4-8012-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b3020a-a656-11e4-8012-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 9.9999999999999995e-07, 
         "asm2.asm3._pseudo_1.out0": -9.9999999999999995e-07, 
@@ -1122,13 +1152,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.401719
+    "timestamp": 1422385261.063992
 }
-, "__length_12": 683
+, "__length_12": 679
 , "iteration_case_8": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2a980fd-a23c-11e4-8013-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b32263-a656-11e4-8013-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 9.9999999999999995e-07, 
         "asm2.asm3._pseudo_1.out0": -9.9999999999999995e-07, 
@@ -1141,13 +1171,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.40228
+    "timestamp": 1422385261.064827
 }
-, "__length_13": 704
+, "__length_13": 699
 , "iteration_case_9": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2a9c268-a23c-11e4-8014-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b37adc-a656-11e4-8014-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 1.9328889515693188e-16, 
         "asm2.asm3._pseudo_1.out0": -1.9328889515693188e-16, 
@@ -1160,13 +1190,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.403962
+    "timestamp": 1422385261.067086
 }
-, "__length_14": 684
+, "__length_14": 679
 , "iteration_case_10": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2a9e8b0-a23c-11e4-8015-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b3b111-a656-11e4-8015-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 9.9999999999999995e-07, 
         "asm2.asm3._pseudo_1.out0": -9.9999999999999995e-07, 
@@ -1179,13 +1209,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.404926
+    "timestamp": 1422385261.068471
 }
-, "__length_15": 684
+, "__length_15": 679
 , "iteration_case_11": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2a9fe87-a23c-11e4-8016-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b3d145-a656-11e4-8016-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 9.9999999999999995e-07, 
         "asm2.asm3._pseudo_1.out0": -9.9999999999999995e-07, 
@@ -1198,13 +1228,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.405489
+    "timestamp": 1422385261.069297
 }
-, "__length_16": 704
+, "__length_16": 698
 , "iteration_case_12": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2aa3e82-a23c-11e4-8017-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b42630-a656-11e4-8017-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 1.9328889515693188e-16, 
         "asm2.asm3._pseudo_1.out0": -1.9328889515693188e-16, 
@@ -1217,13 +1247,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.407143
+    "timestamp": 1422385261.07147
 }
-, "__length_17": 661
+, "__length_17": 656
 , "iteration_case_13": {
-    "_driver_id": 139760222668464, 
-    "_id": "d2a70051-a23c-11e4-800b-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552475952, 
+    "_id": "d5b01373-a656-11e4-800b-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "_pseudo_0.out0": 0.0, 
         "_pseudo_1.out0": -0.0, 
@@ -1240,13 +1270,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.409099
+    "timestamp": 1422385261.073931
 }
-, "__length_18": 637
+, "__length_18": 632
 , "iteration_case_14": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2aac17d-a23c-11e4-801a-3c970e57723f", 
-    "_parent_id": "d2aab15c-a23c-11e4-8019-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b4d382-a656-11e4-801a-001f5b354a5c", 
+    "_parent_id": "d5b4bc11-a656-11e4-8019-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 0.0, 
         "asm2.asm3._pseudo_1.out0": -0.0, 
@@ -1259,13 +1289,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.410476
+    "timestamp": 1422385261.075907
 }
-, "__length_19": 637
+, "__length_19": 632
 , "iteration_case_15": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2aad6e6-a23c-11e4-801b-3c970e57723f", 
-    "_parent_id": "d2aab15c-a23c-11e4-8019-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b4f375-a656-11e4-801b-001f5b354a5c", 
+    "_parent_id": "d5b4bc11-a656-11e4-8019-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 0.0, 
         "asm2.asm3._pseudo_1.out0": -0.0, 
@@ -1278,13 +1308,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.411094
+    "timestamp": 1422385261.076721
 }
-, "__length_20": 741
+, "__length_20": 737
 , "iteration_case_16": {
-    "_driver_id": 139760222667984, 
-    "_id": "d2aab15c-a23c-11e4-8019-3c970e57723f", 
-    "_parent_id": "d2aaa1e3-a23c-11e4-8018-3c970e57723f", 
+    "_driver_id": 4552475472, 
+    "_id": "d5b4bc11-a656-11e4-8019-001f5b354a5c", 
+    "_parent_id": "d5b4a6ca-a656-11e4-8018-001f5b354a5c", 
     "data": {
         "asm2._pseudo_0.out0": 0.0, 
         "asm2._pseudo_1.out0": -0.0, 
@@ -1301,13 +1331,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.41266
+    "timestamp": 1422385261.078749
 }
-, "__length_21": 637
+, "__length_21": 632
 , "iteration_case_17": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2ab3d47-a23c-11e4-801d-3c970e57723f", 
-    "_parent_id": "d2ab2ca3-a23c-11e4-801c-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b57aee-a656-11e4-801d-001f5b354a5c", 
+    "_parent_id": "d5b5634a-a656-11e4-801c-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 0.0, 
         "asm2.asm3._pseudo_1.out0": -0.0, 
@@ -1320,13 +1350,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.413649
+    "timestamp": 1422385261.080189
 }
-, "__length_22": 637
+, "__length_22": 632
 , "iteration_case_18": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2ab52d7-a23c-11e4-801e-3c970e57723f", 
-    "_parent_id": "d2ab2ca3-a23c-11e4-801c-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b59af5-a656-11e4-801e-001f5b354a5c", 
+    "_parent_id": "d5b5634a-a656-11e4-801c-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 0.0, 
         "asm2.asm3._pseudo_1.out0": -0.0, 
@@ -1339,13 +1369,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.414204
+    "timestamp": 1422385261.081018
 }
-, "__length_23": 742
+, "__length_23": 737
 , "iteration_case_19": {
-    "_driver_id": 139760222667984, 
-    "_id": "d2ab2ca3-a23c-11e4-801c-3c970e57723f", 
-    "_parent_id": "d2aaa1e3-a23c-11e4-8018-3c970e57723f", 
+    "_driver_id": 4552475472, 
+    "_id": "d5b5634a-a656-11e4-801c-001f5b354a5c", 
+    "_parent_id": "d5b4a6ca-a656-11e4-8018-001f5b354a5c", 
     "data": {
         "asm2._pseudo_0.out0": 0.0, 
         "asm2._pseudo_1.out0": -0.0, 
@@ -1362,13 +1392,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.415786
+    "timestamp": 1422385261.083043
 }
-, "__length_24": 684
+, "__length_24": 678
 , "iteration_case_20": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2abb4bd-a23c-11e4-801f-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b61dc7-a656-11e4-801f-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 9.9999999999999995e-07, 
         "asm2.asm3._pseudo_1.out0": -9.9999999999999995e-07, 
@@ -1381,13 +1411,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.416708
+    "timestamp": 1422385261.08436
 }
-, "__length_25": 684
+, "__length_25": 679
 , "iteration_case_21": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2abca73-a23c-11e4-8020-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b63e33-a656-11e4-8020-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 9.9999999999999995e-07, 
         "asm2.asm3._pseudo_1.out0": -9.9999999999999995e-07, 
@@ -1400,13 +1430,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.417268
+    "timestamp": 1422385261.085191
 }
-, "__length_26": 704
+, "__length_26": 699
 , "iteration_case_22": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2ac0c00-a23c-11e4-8021-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b69366-a656-11e4-8021-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 1.9328889515693188e-16, 
         "asm2.asm3._pseudo_1.out0": -1.9328889515693188e-16, 
@@ -1419,13 +1449,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.418955
+    "timestamp": 1422385261.087375
 }
-, "__length_27": 683
+, "__length_27": 679
 , "iteration_case_23": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2ac3270-a23c-11e4-8022-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b6c9d9-a656-11e4-8022-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 9.9999999999999995e-07, 
         "asm2.asm3._pseudo_1.out0": -9.9999999999999995e-07, 
@@ -1438,13 +1468,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.41992
+    "timestamp": 1422385261.088763
 }
-, "__length_28": 683
+, "__length_28": 679
 , "iteration_case_24": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2ac4800-a23c-11e4-8023-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b6e9cf-a656-11e4-8023-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 9.9999999999999995e-07, 
         "asm2.asm3._pseudo_1.out0": -9.9999999999999995e-07, 
@@ -1457,13 +1487,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.42048
+    "timestamp": 1422385261.089587
 }
-, "__length_29": 704
+, "__length_29": 699
 , "iteration_case_25": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2ac882e-a23c-11e4-8024-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b73f0a-a656-11e4-8024-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 1.9328889515693188e-16, 
         "asm2.asm3._pseudo_1.out0": -1.9328889515693188e-16, 
@@ -1476,13 +1506,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.422138
+    "timestamp": 1422385261.091766
 }
-, "__length_30": 661
+, "__length_30": 656
 , "iteration_case_26": {
-    "_driver_id": 139760222668464, 
-    "_id": "d2aaa1e3-a23c-11e4-8018-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552475952, 
+    "_id": "d5b4a6ca-a656-11e4-8018-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "_pseudo_0.out0": 0.0, 
         "_pseudo_1.out0": -0.0, 
@@ -1499,13 +1529,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.423634
+    "timestamp": 1422385261.093613
 }
-, "__length_31": 698
+, "__length_31": 693
 , "iteration_case_27": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2acff51-a23c-11e4-8026-3c970e57723f", 
-    "_parent_id": "d2acef30-a23c-11e4-8025-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b7dbca-a656-11e4-8026-001f5b354a5c", 
+    "_parent_id": "d5b7c10a-a656-11e4-8025-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 9.9999999999999995e-07, 
         "asm2.asm3._pseudo_1.out0": -9.9999999999999995e-07, 
@@ -1518,13 +1548,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.425169
+    "timestamp": 1422385261.095779
 }
-, "__length_32": 697
+, "__length_32": 691
 , "iteration_case_28": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2ad151e-a23c-11e4-8027-3c970e57723f", 
-    "_parent_id": "d2acef30-a23c-11e4-8025-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b7fbf0-a656-11e4-8027-001f5b354a5c", 
+    "_parent_id": "d5b7c10a-a656-11e4-8025-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 9.9999999999999995e-07, 
         "asm2.asm3._pseudo_1.out0": -9.9999999999999995e-07, 
@@ -1537,13 +1567,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.42573
+    "timestamp": 1422385261.0966
 }
-, "__length_33": 718
+, "__length_33": 713
 , "iteration_case_29": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2ad555e-a23c-11e4-8028-3c970e57723f", 
-    "_parent_id": "d2acef30-a23c-11e4-8025-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b850c0-a656-11e4-8028-001f5b354a5c", 
+    "_parent_id": "d5b7c10a-a656-11e4-8025-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 1.9328889515693188e-16, 
         "asm2.asm3._pseudo_1.out0": -1.9328889515693188e-16, 
@@ -1556,13 +1586,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.427402
+    "timestamp": 1422385261.098773
 }
-, "__length_34": 824
+, "__length_34": 819
 , "iteration_case_30": {
-    "_driver_id": 139760222667984, 
-    "_id": "d2acef30-a23c-11e4-8025-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552475472, 
+    "_id": "d5b7c10a-a656-11e4-8025-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2._pseudo_0.out0": 1.9328889515693188e-16, 
         "asm2._pseudo_1.out0": -9.9999999999999995e-07, 
@@ -1579,13 +1609,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.427814
+    "timestamp": 1422385261.099365
 }
-, "__length_35": 698
+, "__length_35": 693
 , "iteration_case_31": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2ad8dc0-a23c-11e4-802a-3c970e57723f", 
-    "_parent_id": "d2ad7c85-a23c-11e4-8029-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b89f94-a656-11e4-802a-001f5b354a5c", 
+    "_parent_id": "d5b88823-a656-11e4-8029-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 9.9999999999999995e-07, 
         "asm2.asm3._pseudo_1.out0": -9.9999999999999995e-07, 
@@ -1598,13 +1628,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.428826
+    "timestamp": 1422385261.100786
 }
-, "__length_36": 698
+, "__length_36": 693
 , "iteration_case_32": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2ada497-a23c-11e4-802b-3c970e57723f", 
-    "_parent_id": "d2ad7c85-a23c-11e4-8029-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b8bf54-a656-11e4-802b-001f5b354a5c", 
+    "_parent_id": "d5b88823-a656-11e4-8029-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 9.9999999999999995e-07, 
         "asm2.asm3._pseudo_1.out0": -9.9999999999999995e-07, 
@@ -1617,13 +1647,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.429438
+    "timestamp": 1422385261.101609
 }
-, "__length_37": 718
+, "__length_37": 713
 , "iteration_case_33": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2ade854-a23c-11e4-802c-3c970e57723f", 
-    "_parent_id": "d2ad7c85-a23c-11e4-8029-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b9147d-a656-11e4-802c-001f5b354a5c", 
+    "_parent_id": "d5b88823-a656-11e4-8029-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 1.9328889515693188e-16, 
         "asm2.asm3._pseudo_1.out0": -1.9328889515693188e-16, 
@@ -1636,13 +1666,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.431157
+    "timestamp": 1422385261.103788
 }
-, "__length_38": 825
+, "__length_38": 821
 , "iteration_case_34": {
-    "_driver_id": 139760222667984, 
-    "_id": "d2ad7c85-a23c-11e4-8029-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552475472, 
+    "_id": "d5b88823-a656-11e4-8029-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2._pseudo_0.out0": 1.9328889515693188e-16, 
         "asm2._pseudo_1.out0": -9.9999999999999995e-07, 
@@ -1659,13 +1689,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.43157
+    "timestamp": 1422385261.104385
 }
-, "__length_39": 684
+, "__length_39": 679
 , "iteration_case_35": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2ae1d5e-a23c-11e4-802d-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b95fba-a656-11e4-802d-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 1.9999999999999999e-06, 
         "asm2.asm3._pseudo_1.out0": -1.9999999999999999e-06, 
@@ -1678,13 +1708,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.432491
+    "timestamp": 1422385261.105706
 }
-, "__length_40": 683
+, "__length_40": 679
 , "iteration_case_36": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2ae5c6b-a23c-11e4-802e-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b97f73-a656-11e4-802e-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 1.9999999999999999e-06, 
         "asm2.asm3._pseudo_1.out0": -1.9999999999999999e-06, 
@@ -1697,13 +1727,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.43415
+    "timestamp": 1422385261.106528
 }
-, "__length_41": 704
+, "__length_41": 699
 , "iteration_case_37": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2ae9f7d-a23c-11e4-802f-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5b9d4a3-a656-11e4-802f-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 2.7555591136782173e-16, 
         "asm2.asm3._pseudo_1.out0": -2.7555591136782173e-16, 
@@ -1716,13 +1746,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.435843
+    "timestamp": 1422385261.108703
 }
-, "__length_42": 684
+, "__length_42": 679
 , "iteration_case_38": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2aef211-a23c-11e4-8030-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5ba4235-a656-11e4-8030-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 1.9999999999999999e-06, 
         "asm2.asm3._pseudo_1.out0": -1.9999999999999999e-06, 
@@ -1735,13 +1765,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.437943
+    "timestamp": 1422385261.111502
 }
-, "__length_43": 684
+, "__length_43": 679
 , "iteration_case_39": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2af07fa-a23c-11e4-8031-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5ba6214-a656-11e4-8031-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 1.9999999999999999e-06, 
         "asm2.asm3._pseudo_1.out0": -1.9999999999999999e-06, 
@@ -1754,13 +1784,13 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.438502
+    "timestamp": 1422385261.112326
 }
-, "__length_44": 704
+, "__length_44": 699
 , "iteration_case_40": {
-    "_driver_id": 139760222667504, 
-    "_id": "d2af49b0-a23c-11e4-8032-3c970e57723f", 
-    "_parent_id": "d2a63d70-a23c-11e4-aa19-3c970e57723f", 
+    "_driver_id": 4552474992, 
+    "_id": "d5bab735-a656-11e4-8032-001f5b354a5c", 
+    "_parent_id": "d5af15f8-a656-11e4-9216-001f5b354a5c", 
     "data": {
         "asm2.asm3._pseudo_0.out0": 2.7555591136782173e-16, 
         "asm2.asm3._pseudo_1.out0": -2.7555591136782173e-16, 
@@ -1773,6 +1803,6 @@
     }, 
     "error_message": "", 
     "error_status": null, 
-    "timestamp": 1421934284.440199
+    "timestamp": 1422385261.114504
 }
 }

--- a/openmdao.lib/src/openmdao/lib/casehandlers/test/test_datadump.py
+++ b/openmdao.lib/src/openmdao/lib/casehandlers/test/test_datadump.py
@@ -102,6 +102,7 @@ Constants:
    driver.gradient_options.fd_step: 1e-06
    driver.gradient_options.fd_step_type: absolute
    driver.gradient_options.force_fd: False
+   driver.gradient_options.iprint: 0
    driver.gradient_options.lin_solver: scipy_gmres
    driver.gradient_options.maxiter: 100
    driver.gradient_options.rtol: 1e-09
@@ -139,6 +140,7 @@ Constants:
    nested.doublenest.driver.gradient_options.fd_step: 1e-06
    nested.doublenest.driver.gradient_options.fd_step_type: absolute
    nested.doublenest.driver.gradient_options.force_fd: False
+   nested.doublenest.driver.gradient_options.iprint: 0
    nested.doublenest.driver.gradient_options.lin_solver: scipy_gmres
    nested.doublenest.driver.gradient_options.maxiter: 100
    nested.doublenest.driver.gradient_options.rtol: 1e-09
@@ -157,6 +159,7 @@ Constants:
    nested.driver.gradient_options.fd_step: 1e-06
    nested.driver.gradient_options.fd_step_type: absolute
    nested.driver.gradient_options.force_fd: False
+   nested.driver.gradient_options.iprint: 0
    nested.driver.gradient_options.lin_solver: scipy_gmres
    nested.driver.gradient_options.maxiter: 100
    nested.driver.gradient_options.rtol: 1e-09
@@ -328,6 +331,7 @@ Constants:
    driver.gradient_options.fd_step: 1e-06
    driver.gradient_options.fd_step_type: absolute
    driver.gradient_options.force_fd: False
+   driver.gradient_options.iprint: 0
    driver.gradient_options.lin_solver: scipy_gmres
    driver.gradient_options.maxiter: 100
    driver.gradient_options.rtol: 1e-09
@@ -392,6 +396,7 @@ Constants:
    driver.gradient_options.fd_step: 1e-06
    driver.gradient_options.fd_step_type: absolute
    driver.gradient_options.force_fd: False
+   driver.gradient_options.iprint: 0
    driver.gradient_options.lin_solver: scipy_gmres
    driver.gradient_options.maxiter: 100
    driver.gradient_options.rtol: 1e-09

--- a/openmdao.lib/src/openmdao/lib/casehandlers/test/test_dumpcaserecorder.py
+++ b/openmdao.lib/src/openmdao/lib/casehandlers/test/test_dumpcaserecorder.py
@@ -89,6 +89,7 @@ Constants:
    driver.gradient_options.fd_step: 1e-06
    driver.gradient_options.fd_step_type: absolute
    driver.gradient_options.force_fd: False
+   driver.gradient_options.iprint: 0
    driver.gradient_options.lin_solver: scipy_gmres
    driver.gradient_options.maxiter: 100
    driver.gradient_options.rtol: 1e-09
@@ -212,6 +213,7 @@ Constants:
    driver.gradient_options.fd_step: 1e-06
    driver.gradient_options.fd_step_type: absolute
    driver.gradient_options.force_fd: False
+   driver.gradient_options.iprint: 0
    driver.gradient_options.lin_solver: scipy_gmres
    driver.gradient_options.maxiter: 100
    driver.gradient_options.rtol: 1e-09

--- a/openmdao.lib/src/openmdao/lib/casehandlers/test/test_jsonrecorder.py
+++ b/openmdao.lib/src/openmdao/lib/casehandlers/test/test_jsonrecorder.py
@@ -90,8 +90,8 @@ class TestCase(unittest.TestCase):
         self.top.recorders = [JSONCaseRecorder(sout)]
         self.top.run()
 
-        # with open('jsonrecorder.new', 'w') as out:
-        #     out.write(sout.getvalue())
+        with open('jsonrecorder.new', 'w') as out:
+            out.write(sout.getvalue())
         verify_json(self, sout, 'jsonrecorder.json')
 
     def test_multiple_objectives(self):

--- a/openmdao.lib/src/openmdao/lib/casehandlers/test/test_jsonrecorder.py
+++ b/openmdao.lib/src/openmdao/lib/casehandlers/test/test_jsonrecorder.py
@@ -91,7 +91,7 @@ class TestCase(unittest.TestCase):
         self.top.run()
 
         # with open('jsonrecorder.new', 'w') as out:
-        #      out.write(sout.getvalue())
+        #     out.write(sout.getvalue())
         verify_json(self, sout, 'jsonrecorder.json')
 
     def test_multiple_objectives(self):

--- a/openmdao.lib/src/openmdao/lib/casehandlers/test/test_jsonrecorder.py
+++ b/openmdao.lib/src/openmdao/lib/casehandlers/test/test_jsonrecorder.py
@@ -90,8 +90,8 @@ class TestCase(unittest.TestCase):
         self.top.recorders = [JSONCaseRecorder(sout)]
         self.top.run()
 
-        with open('jsonrecorder.new', 'w') as out:
-            out.write(sout.getvalue())
+        # with open('jsonrecorder.new', 'w') as out:
+        #      out.write(sout.getvalue())
         verify_json(self, sout, 'jsonrecorder.json')
 
     def test_multiple_objectives(self):

--- a/openmdao.lib/src/openmdao/lib/drivers/iterate.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/iterate.py
@@ -40,6 +40,9 @@ class FixedPointIterator(Driver):
                        desc='For multivariable iteration, type of norm '
                                    'to use to test convergence.')
 
+    iprint = Enum(0, [0, 1], iotype='in', desc='set to 1 to print '
+                  'convergence..')
+
     def __init__(self):
         super(FixedPointIterator, self).__init__()
         self.current_iteration = 0
@@ -72,7 +75,10 @@ class FixedPointIterator(Driver):
         self.run_iteration()
         self.normval = self.norm()
         self.norm0 = self.normval if self.normval != 0.0 else 1.0
-
+        
+        if self.iprint > 0:
+            self.print_norm('NLN_GS', 0, self.normval, self.norm0)
+       
     def run_iteration(self):
         """Runs an iteration."""
         self.current_iteration += 1
@@ -97,8 +103,16 @@ class FixedPointIterator(Driver):
     def post_iteration(self):
         """Runs after each iteration"""
         self.normval = self.norm()
-        #print "iter %d, norm = %s" % (self.current_iteration, self.normval)
+        if self.iprint > 0:
+            self.print_norm('NLN_GS', self.current_iteration-1, self.normval, 
+                            self.norm0)
 
+    def end_iteration(self):
+        """Print convergence."""
+        if self.iprint > 0:
+            self.print_norm('NLN_GS', self.current_iteration-1, self.normval, 
+                            self.norm0, msg='Converged')
+        
     def _mpi_norm(self):
         """ Compute the norm of the f Vec using petsc. """
         fvec = self.workflow._system.vec['f']

--- a/openmdao.lib/src/openmdao/lib/drivers/iterate.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/iterate.py
@@ -41,7 +41,7 @@ class FixedPointIterator(Driver):
                                    'to use to test convergence.')
 
     iprint = Enum(0, [0, 1], iotype='in', desc='set to 1 to print '
-                  'convergence..')
+                  'residual during convergence.')
 
     def __init__(self):
         super(FixedPointIterator, self).__init__()

--- a/openmdao.lib/src/openmdao/lib/drivers/newton_solver.py
+++ b/openmdao.lib/src/openmdao/lib/drivers/newton_solver.py
@@ -78,6 +78,7 @@ class NewtonSolver(Driver):
         dfvec = system.vec['df']
         uvec = system.vec['u']
         iterbase = self.workflow._iterbase()
+        nstring = 'NEWTON'
 
         # perform an initial run
         self.workflow._system.evaluate(iterbase, case_uuid=Case.next_uuid())
@@ -85,8 +86,8 @@ class NewtonSolver(Driver):
         f_norm = self.norm()
         f_norm0 = f_norm
 
-        if self.iprint == 1:
-            print self.name, "Norm: ", f_norm, 0
+        if self.iprint > 0:
+            self.print_norm(nstring, 0, f_norm, f_norm0)
 
         itercount = 0
         alpha = self.alpha
@@ -102,8 +103,8 @@ class NewtonSolver(Driver):
             self.workflow._system.evaluate(iterbase, case_uuid=Case.next_uuid())
 
             f_norm = self.norm()
-            if self.iprint == 1:
-                print self.name, "Norm: ", f_norm, itercount+1
+            if self.iprint > 0:
+                self.print_norm(nstring, itercount+1, f_norm, f_norm0)
 
             itercount += 1
             ls_itercount = 0
@@ -121,8 +122,8 @@ class NewtonSolver(Driver):
                                                case_uuid=Case.next_uuid())
 
                 f_norm = self.norm()
-                if self.iprint == 2:
-                    print "Backtracking Norm: %f, Alpha: %f" % (f_norm, alpha)
+                if self.iprint> 1:
+                    self.print_norm('BK_TKG', itercount+1, f_norm, f_norm/f_norm0, indent=1, solver='LS')
 
                 ls_itercount += 1
 
@@ -135,8 +136,8 @@ class NewtonSolver(Driver):
         self.run_iteration()
         self.post_iteration()
 
-        if self.iprint == 1:
-            print self.name, "converged"
+        if self.iprint > 0:
+            self.print_norm(nstring, itercount, f_norm, f_norm0, msg='Converged')
 
     def _mpi_norm(self):
         """ Compute the norm of the f Vec using petsc. """

--- a/openmdao.main/src/openmdao/main/driver.py
+++ b/openmdao.main/src/openmdao/main/driver.py
@@ -538,6 +538,24 @@ class Driver(Component):
             self._system = self.parent._reduced_graph.node[self.name]['system']
             self.workflow.setup_systems(self.system_type)
 
+    def print_norm(self, driver_string, iteration, res, res0, msg=None, indent=0, solver='NL'):
+        """ Prints out the norm of the residual in a neat readable format.
+        """
+
+        # Find indentation level
+        if self.itername == '-driver':
+            level = 0 + indent
+        else:
+            level = self.itername.count('.') + 1 + indent
+            
+        indent = '   ' * level
+        if msg is not None:
+            form = indent + '[%s] %s: %s   %d | %s'
+            print form % (self.name, solver, driver_string, iteration, msg)
+            return
+
+        form = indent + '[%s] %s: %s   %d | %.9g %.9g'
+        print form % (self.name, solver, driver_string, iteration, res, res/res0)
 
     #### MPI related methods ####
 

--- a/openmdao.main/src/openmdao/main/driver.py
+++ b/openmdao.main/src/openmdao/main/driver.py
@@ -91,6 +91,10 @@ class GradientOptions(VariableTree):
     maxiter = Int(100, desc='Maximum number of iterations for the linear solver.',
                   framework_var=True)
 
+    iprint = Enum(0, [0, 1], desc="Set to 1 to print out residual of the linear solver",
+                  framework_var=True)
+
+
     def _lin_solver_changed(self, oldls, newls):
         # if PETSc has been imported prior to the creation of a remote object using
         # the multiprocessing package, we get errors due to broken socket connections

--- a/openmdao.main/src/openmdao/main/linearsolver.py
+++ b/openmdao.main/src/openmdao/main/linearsolver.py
@@ -65,7 +65,7 @@ class ScipyGMRES(LinearSolver):
     it should never be used in an MPI setting.
     """
     
-    ln_string = 'GMERES'
+    ln_string = 'GMRES'
 
     def __init__(self, system):
         """ Set up ScipyGMRES object """

--- a/openmdao.main/src/openmdao/main/linearsolver.py
+++ b/openmdao.main/src/openmdao/main/linearsolver.py
@@ -17,7 +17,34 @@ class LinearSolver(object):
         """ Set up any LinearSolver object """
         self._system = system
         self.options = system.options
+        
+        # Figure out base indentation for printing the residual during convergence.
+        level = 0
+        if hasattr(system, '_parent_system') and system._parent_system is not None:
+            drv = system._parent_system._comp
+            self.drv_name = drv.name
+            if drv.itername == '-driver':
+                level = 0
+            else:
+                level = drv.itername.count('.') + 1
+                
+        else:
+            self.drv_name = system.name
+            
+        self.indent = '   ' * level
+        
+    def print_norm(self, driver_string, iteration, res, res0, msg=None, solver='LN'):
+        """ Prints out the norm of the residual in a neat readable format.
+        """
 
+        if msg is not None:
+            form = self.indent + '[%s]    %s: %s   %d | %s'
+            print form % (self.drv_name, solver, self.ln_string, iteration, msg)
+            return
+
+        form = self.indent + '[%s]    %s: %s   %d | %.9g %.9g'
+        print form % (self.drv_name, solver, self.ln_string, iteration, res, res/res0)
+        
     def _norm(self):
         """ Computes the norm of the linear residual """
         system = self._system
@@ -37,6 +64,8 @@ class ScipyGMRES(LinearSolver):
     """ Scipy's GMRES Solver. This is a serial solver, so
     it should never be used in an MPI setting.
     """
+    
+    ln_string = 'GMERES'
 
     def __init__(self, system):
         """ Set up ScipyGMRES object """
@@ -177,6 +206,23 @@ class ScipyGMRES(LinearSolver):
 class PETSc_KSP(LinearSolver):
     """ PETSc's KSP solver with preconditioning. MPI is supported."""
 
+    ln_string = 'KSP'
+
+    # This class object is given to KSP as a callback object for printing the residual.
+    class Monitor(object):
+        """ Prints output from PETSc's KSP solvers """
+    
+        def __init__(self, ksp):
+            """ Stores pointer to the ksp solver """
+            self._ksp = ksp
+            self._norm0 = 1.0
+    
+        def __call__(self, ksp, counter, norm):
+            """ Store norm if first iteration, and print norm """
+            if counter == 0 and norm != 0.0:
+                self._norm0 = norm
+            self._ksp.print_norm(self._ksp.ln_string, counter, norm, self._norm0)
+    
     def __init__(self, system):
         """ Set up KSP object """
         super(PETSc_KSP, self).__init__(system)
@@ -193,6 +239,7 @@ class PETSc_KSP(LinearSolver):
         self.ksp.setType('fgmres')
         self.ksp.setGMRESRestart(1000)
         self.ksp.setPCSide(PETSc.PC.Side.RIGHT)
+        self.ksp.setMonitor(self.Monitor(self))
 
         pc_mat = self.ksp.getPC()
         pc_mat.setType('python')
@@ -349,6 +396,8 @@ class LinearGS(LinearSolver):
     """ Linear block Gauss Seidel. MPI is not supported yet.
     Serial block solve of D x = b - (L+U) x """
 
+    ln_string = 'LIN_GS'
+
     def __init__(self, system):
         """ Set up LinearGS object """
         super(LinearGS, self).__init__(system)
@@ -456,6 +505,8 @@ class LinearGS(LinearSolver):
 
         norm0, norm = 1.0, 1.0
         counter = 0
+        self.print_norm(self.ln_string, counter, norm, norm0)
+        
         while counter < options.maxiter and norm > options.atol and \
               norm/norm0 > options.rtol:
 
@@ -498,8 +549,10 @@ class LinearGS(LinearSolver):
                             system.vec['dp'].array[:] = 0.0
                     system.rhs_vec.array[:] = system.sol_buf[:]
                     subsystem.solve_linear(options)
+                    
             norm = self._norm()
             counter += 1
+            self.print_norm(self.ln_string, counter, norm, norm0)
 
         #print 'return', options.parent.name, np.linalg.norm(system.rhs_vec.array), system.rhs_vec.array
         #print 'Linear solution vec', system.sol_vec.array

--- a/openmdao.main/src/openmdao/main/linearsolver.py
+++ b/openmdao.main/src/openmdao/main/linearsolver.py
@@ -221,7 +221,9 @@ class PETSc_KSP(LinearSolver):
             """ Store norm if first iteration, and print norm """
             if counter == 0 and norm != 0.0:
                 self._norm0 = norm
-            self._ksp.print_norm(self._ksp.ln_string, counter, norm, self._norm0)
+                
+            if self._ksp.options.iprint > 0:
+                self._ksp.print_norm(self._ksp.ln_string, counter, norm, self._norm0)
     
     def __init__(self, system):
         """ Set up KSP object """
@@ -505,7 +507,8 @@ class LinearGS(LinearSolver):
 
         norm0, norm = 1.0, 1.0
         counter = 0
-        self.print_norm(self.ln_string, counter, norm, norm0)
+        if self.options.iprint > 0:
+            self.print_norm(self.ln_string, counter, norm, norm0)
         
         while counter < options.maxiter and norm > options.atol and \
               norm/norm0 > options.rtol:
@@ -552,7 +555,8 @@ class LinearGS(LinearSolver):
                     
             norm = self._norm()
             counter += 1
-            self.print_norm(self.ln_string, counter, norm, norm0)
+            if self.options.iprint > 0:
+                self.print_norm(self.ln_string, counter, norm, norm0)
 
         #print 'return', options.parent.name, np.linalg.norm(system.rhs_vec.array), system.rhs_vec.array
         #print 'Linear solution vec', system.sol_vec.array


### PR DESCRIPTION
Standardized printing of residuals from the linear and nonlinear solvers.

Supported nonlinear solvers: NewtonSolver, FixedPointIterator
Supported linear solvers: petsc_ksp, lin_gs

Note: scipy gmres does not support per-iteration output of the residual.