### PR TITLE
Custom constraint jacobians

### DIFF
--- a/openmdao.main/src/openmdao/main/hasconstraints.py
+++ b/openmdao.main/src/openmdao/main/hasconstraints.py
@@ -64,7 +64,7 @@ def _get_scope(obj, scope=None):
 class Constraint(object):
     """ Object that stores info for a single constraint. """
 
-    def __init__(self, lhs, comparator, rhs, scope):
+    def __init__(self, lhs, comparator, rhs, scope, jacs=None):
         self.lhs = ExprEvaluator(lhs, scope=scope)
         unresolved_vars = self.lhs.get_unresolved()
 
@@ -91,6 +91,9 @@ class Constraint(object):
 
         # Linear flag: constraints are nonlinear by default
         self.linear = False
+        
+        # User-defined jacobian function
+        self.jacs = jacs
 
     @property
     def size(self):
@@ -227,7 +230,7 @@ class Constraint(object):
     def copy(self):
         """ Returns a copy of our self. """
         return Constraint(str(self.lhs), self.comparator, str(self.rhs),
-                          scope=self.lhs.scope)
+                          scope=self.lhs.scope, jacs=self.jacs)
 
     def evaluate(self, scope):
         """Returns the value of the constraint as a sequence."""
@@ -286,7 +289,7 @@ class Constraint(object):
 class Constraint2Sided(Constraint):
     """ Object that stores info for a double-sided constraint. """
 
-    def __init__(self, lhs, center, rhs, comparator, scope):
+    def __init__(self, lhs, center, rhs, comparator, scope, jacs=None):
         self.lhs = ExprEvaluator(lhs, scope=scope)
         unresolved_vars = self.lhs.get_unresolved()
 
@@ -329,6 +332,9 @@ class Constraint2Sided(Constraint):
 
         self.low = self.lhs.evaluate()
         self.high = self.rhs.evaluate()
+        
+        # User-defined jacobian function
+        self.jacs = jacs
 
     def activate(self, driver):
         """Make this constraint active by creating the appropriate
@@ -362,7 +368,8 @@ class Constraint2Sided(Constraint):
     def copy(self):
         """ Returns a copy of our self. """
         return Constraint2Sided(str(self.lhs), str(self.center), str(self.rhs),
-                          self.comparator, scope=self.lhs.scope)
+                          self.comparator, scope=self.lhs.scope, 
+                          jacs=self.jacs)
 
     def get_referenced_compnames(self):
         """Returns a set of names of each component referenced by this
@@ -555,7 +562,8 @@ class HasEqConstraints(_HasConstraintsBase):
     constraints but does not support inequality constraints.
     """
 
-    def add_constraint(self, expr_string, name=None, scope=None, linear=False):
+    def add_constraint(self, expr_string, name=None, scope=None, linear=False, 
+                       jacs=None):
         """Adds a constraint in the form of a boolean expression string
         to the driver.
 
@@ -573,6 +581,12 @@ class HasEqConstraints(_HasConstraintsBase):
             Set this to True to define this constraint is linear. Behavior
             depends on whether and how your optimizer supports it. Deault is
             False or nonlinear constraint.
+            
+        jacs: dict
+            Dictionary of user-defined functions that return the flattened
+            Jacobian of this constraint with repsect to the parameters of
+            the driver, as indicated by the dictionary keys. Default is None
+            to let OpenMDAO determine the derivatives.
         """
         try:
             lhs, rel, rhs = _parse_constraint(expr_string)
@@ -580,13 +594,13 @@ class HasEqConstraints(_HasConstraintsBase):
             self.parent.raise_exception(str(err), type(err))
         if rel == '=':
             self._add_eq_constraint(lhs, rhs, name=name, scope=scope,
-                                    linear=linear)
+                                    linear=linear, jacs=jacs)
         else:
             msg = "Inequality constraints are not supported on this driver"
             self.parent.raise_exception(msg, ValueError)
 
     def _add_eq_constraint(self, lhs, rhs, name=None, scope=None,
-                           linear=False):
+                           linear=False, jacs=None):
         """Adds an equality constraint as two strings, a left-hand side and
         a right-hand side.
         """
@@ -606,7 +620,8 @@ class HasEqConstraints(_HasConstraintsBase):
                                         ' in the driver. Add failed.'
                                         % name, ValueError)
 
-        constraint = Constraint(lhs, '=', rhs, scope=_get_scope(self, scope))
+        constraint = Constraint(lhs, '=', rhs, scope=_get_scope(self, scope), 
+                                jacs=jacs)
         constraint.linear = linear
 
         if IDriver.providedBy(self.parent):
@@ -652,7 +667,6 @@ class HasEqConstraints(_HasConstraintsBase):
             return dict((key, value) for key, value in self._constraints.iteritems() \
                         if value.linear==linear)
 
-
     def total_eq_constraints(self):
         """Returns the total number of constraint values."""
         return sum([c.size for c in self._constraints.values()])
@@ -691,7 +705,8 @@ class HasIneqConstraints(_HasConstraintsBase):
     constraints but does not support equality constraints.
     """
 
-    def add_constraint(self, expr_string, name=None, scope=None, linear=False):
+    def add_constraint(self, expr_string, name=None, scope=None, linear=False,
+                       jacs=None):
         """Adds a constraint in the form of a boolean expression string
         to the driver.
 
@@ -709,16 +724,22 @@ class HasIneqConstraints(_HasConstraintsBase):
             Set this to True to define this constraint is linear. Behavior
             depends on whether and how your optimizer supports it. Deault is
             False or nonlinear constraint.
+
+        jacs: dict
+            Dictionary of user-defined functions that return the flattened
+            Jacobian of this constraint with repsect to the parameters of
+            the driver, as indicated by the dictionary keys. Default is None
+            to let OpenMDAO determine the derivatives.
         """
         try:
             lhs, rel, rhs = _parse_constraint(expr_string)
         except Exception as err:
             self.parent.raise_exception(str(err), type(err))
         self._add_ineq_constraint(lhs, rel, rhs, name=name, scope=scope,
-                                  linear=linear)
+                                  linear=linear, jacs=jacs)
 
     def _add_ineq_constraint(self, lhs, rel, rhs, name=None, scope=None,
-                             linear=False):
+                             linear=False, jacs=None):
         """Adds an inequality constraint as three strings; a left-hand side,
         a comparator ('<','>','<=', or '>='), and a right-hand side.
         """
@@ -742,8 +763,10 @@ class HasIneqConstraints(_HasConstraintsBase):
                                         ' in the driver. Add failed.'
                                         % name, ValueError)
 
-        constraint = Constraint(lhs, rel, rhs, scope=_get_scope(self, scope))
+        constraint = Constraint(lhs, rel, rhs, scope=_get_scope(self, scope), 
+                                jacs=jacs)
         constraint.linear = linear
+        
         if IDriver.providedBy(self.parent):
             constraint.activate(self.parent)
             self.parent.config_changed()
@@ -861,7 +884,8 @@ class HasConstraints(object):
         """
         return self._eq._item_count() + self._ineq._item_count()
 
-    def add_constraint(self, expr_string, name=None, scope=None, linear=False):
+    def add_constraint(self, expr_string, name=None, scope=None, linear=False,
+                       jacs=None):
         """Adds a constraint in the form of a boolean expression string
         to the driver.
 
@@ -879,6 +903,12 @@ class HasConstraints(object):
             Set this to True to define this constraint is linear. Behavior
             depends on whether and how your optimizer supports it. Deault is
             False or nonlinear constraint.
+            
+        jacs: dict
+            Dictionary of user-defined functions that return the flattened
+            Jacobian of this constraint with repsect to the parameters of
+            the driver, as indicated by the dictionary keys. Default is None
+            to let OpenMDAO determine the derivatives.
         """
         try:
             lhs, rel, rhs = _parse_constraint(expr_string)
@@ -886,17 +916,18 @@ class HasConstraints(object):
             self.parent.raise_exception(str(err), type(err))
         if rel == '=':
             self._eq._add_eq_constraint(lhs, rhs, name=name, scope=scope,
-                                        linear=linear)
+                                        linear=linear, jacs=jacs)
         elif isinstance(rhs, tuple):
             if not IHas2SidedConstraints.providedBy(self.parent):
                 msg = 'Double-sided constraints are not supported on ' + \
                       'this driver.'
                 self.parent.raise_exception(msg, AttributeError)
-            self.parent.add_2sided_constraint(rhs[0], lhs, rhs[1], rel, name=name,
-                                              scope=scope, linear=linear)
+            self.parent.add_2sided_constraint(rhs[0], lhs, rhs[1], rel, 
+                                              name=name, scope=scope, 
+                                              linear=linear, jacs=jacs)
         else:
             self._ineq._add_ineq_constraint(lhs, rel, rhs, name=name, scope=scope,
-                                            linear=linear)
+                                            linear=linear, jacs=jacs)
 
     def add_existing_constraint(self, scope, constraint, name=None):
         """Adds an existing Constraint object to the driver.
@@ -1111,7 +1142,7 @@ class Has2SidedConstraints(_HasConstraintsBase):
     """
 
     def add_2sided_constraint(self, lhs, center, rhs, rel, name=None, scope=None,
-                               linear=False):
+                               linear=False, jacs=None):
         """Adds an 2-sided constraint as four strings; a left-hand side, a
         center, a right-hand side, and a comparator ('<','>','<=', or '>=')
         """
@@ -1145,7 +1176,7 @@ class Has2SidedConstraints(_HasConstraintsBase):
                                         % name, ValueError)
 
         constraint = Constraint2Sided(lhs, center, rhs, rel,
-                                      scope=_get_scope(self, scope))
+                                      scope=_get_scope(self, scope), jacs=jacs)
         constraint.linear = linear
 
         if IDriver.providedBy(self.parent):

--- a/openmdao.main/src/openmdao/main/test/test_hasconstraints.py
+++ b/openmdao.main/src/openmdao/main/test/test_hasconstraints.py
@@ -6,13 +6,14 @@ import unittest
 
 from openmdao.main.api import Assembly, Component, Driver, set_as_top
 from openmdao.main.datatypes.api import Float, Array
-from openmdao.util.decorators import add_delegate
 from openmdao.main.hasconstraints import HasConstraints, HasEqConstraints, \
      HasIneqConstraints, Constraint, Has2SidedConstraints
 from openmdao.main.interfaces import IHas2SidedConstraints, implements
+from openmdao.main.pseudocomp import SimpleEQConPComp, SimpleEQ0PComp
+from openmdao.main.test.simpledriver import SimpleDriver
 from openmdao.test.execcomp import ExecComp
 from openmdao.units.units import PhysicalQuantity
-from openmdao.main.pseudocomp import SimpleEQConPComp, SimpleEQ0PComp
+from openmdao.util.decorators import add_delegate
 from openmdao.util.testutil import assert_rel_error
 
 @add_delegate(HasConstraints)
@@ -450,6 +451,121 @@ class HasConstraintsTestCase(unittest.TestCase):
         result['out0'] = np.array([0.0])
         self.asm._pseudo_4.apply_deriv(arg, result)
         self.assertEqual(result['out0'][0], 4.1)
+        
+    def test_custom_jacobian(self):
+        
+        class AComp(Component):
+            
+            x = Array([[1.0, 3.0], [-2.0, 4.0]], iotype='in')
+            y = Array(np.zeros((2, 2)), iotype='out')
+
+            def __init__(self):
+                super(AComp, self).__init__()
+                self.J = np.array([[3.5, -2.5, 1.5, 4.0],
+                                   [4.0, 2.0, -1.1, 3.4],
+                                   [7.7, 6.6, 4.4, 1.1],
+                                   [0.1, 3.3, 6.8, -5.5]])
+            
+            def execute(self):
+                """ Run arraycomp"""
+                y = self.J.dot(self.x.flatten())
+                self.y = y.reshape((2,2))
+                
+            def list_deriv_vars(self):
+                """ x and y """
+                input_keys = ('x',)
+                output_keys = ('y',)
+                return input_keys, output_keys
+
+            def provideJ(self):
+                """Analytical first derivatives"""
+                return self.J
+            
+            
+        def fake_jac():
+            """ Returns a User-defined Jacobian. The values are
+            totally wrong to facilitate testing. """
+            jacs = {}
+            jacs['comp.x'] = np.array([[100.0, 101, 102, 103],
+                                       [104, 105, 106, 107],
+                                       [108, 109, 110, 111],
+                                       [112, 113, 114, 115]])
+            
+            return jacs
+        
+        top = set_as_top(Assembly())
+        top.add('driver', SimpleDriver())
+        top.add('comp', AComp())
+        top.driver.workflow.add('comp')
+        top.driver.add_parameter('comp.x', low=10, high=10)
+        top.driver.add_constraint('comp.y < 1', jacs=fake_jac)
+        
+        # Scipy gmres, inequality constraints
+        top._setup()
+        top.run()
+        
+        J = top.driver.calc_gradient(mode='forward', return_format='dict')
+        J = J['_pseudo_0.out0']['comp.x']
+        diff = np.abs(J - top.comp.J)
+        assert_rel_error(self, diff.max(), 0.0, 1e-4)
+        
+        J = top.driver.calc_gradient(mode='adjoint', return_format='dict')
+        J = J['_pseudo_0.out0']['comp.x']
+        diff = np.abs(J - fake_jac()['comp.x'])
+        assert_rel_error(self, diff.max(), 0.0, 1e-4)
+
+        # Scipy gmres, equality constraints
+        top.driver.clear_constraints()
+        top._pseudo_count = 0
+        top.driver.add_constraint('comp.y = 1', jacs=fake_jac)
+        top._setup()
+        top.run()
+        
+        J = top.driver.calc_gradient(mode='forward', return_format='dict')
+        J = J['_pseudo_0.out0']['comp.x']
+        diff = np.abs(J - top.comp.J)
+        assert_rel_error(self, diff.max(), 0.0, 1e-4)
+        
+        J = top.driver.calc_gradient(mode='adjoint', return_format='dict')
+        J = J['_pseudo_0.out0']['comp.x']
+        diff = np.abs(J - fake_jac()['comp.x'])
+        assert_rel_error(self, diff.max(), 0.0, 1e-4)
+
+        # Scipy gmres, double-sided constraints
+        top.driver.clear_constraints()
+        top._pseudo_count = 0
+        top.driver.add_constraint('0 < comp.y < 1', jacs=fake_jac)
+        top._setup()
+        top.run()
+        
+        J = top.driver.calc_gradient(mode='forward', return_format='dict')
+        J = J['_pseudo_0.out0']['comp.x']
+        diff = np.abs(J - top.comp.J)
+        assert_rel_error(self, diff.max(), 0.0, 1e-4)
+        
+        J = top.driver.calc_gradient(mode='adjoint', return_format='dict')
+        J = J['_pseudo_0.out0']['comp.x']
+        diff = np.abs(J - fake_jac()['comp.x'])
+        assert_rel_error(self, diff.max(), 0.0, 1e-4)
+
+        # Linear GS, equality constraints
+        top.driver.clear_constraints()
+        top._pseudo_count = 0
+        top.driver.add_constraint('comp.y = 1', jacs=fake_jac)
+        top.driver.gradient_options.lin_solver = 'linear_gs'
+        top._setup()
+        top.run()
+        
+        J = top.driver.calc_gradient(mode='forward', return_format='dict')
+        J = J['_pseudo_0.out0']['comp.x']
+        diff = np.abs(J - top.comp.J)
+        assert_rel_error(self, diff.max(), 0.0, 1e-4)
+        
+        J = top.driver.calc_gradient(mode='adjoint', return_format='dict')
+        J = J['_pseudo_0.out0']['comp.x']
+        diff = np.abs(J - fake_jac()['comp.x'])
+        assert_rel_error(self, diff.max(), 0.0, 1e-4)
+
 
 class Has2SidedConstraintsTestCase(unittest.TestCase):
 

--- a/openmdao.main/src/openmdao/main/workflow.py
+++ b/openmdao.main/src/openmdao/main/workflow.py
@@ -16,11 +16,11 @@ from openmdao.main.mp_support import has_interface
 from openmdao.main.case import Case
 from openmdao.main.mpiwrap import MPI, MPI_info
 from openmdao.main.systems import SerialSystem, ParallelSystem, \
-                                  OpaqueSystem, VarSystem, CompoundSystem, \
-                                  partition_subsystems, ParamSystem, \
-                                  get_comm_if_active, collapse_to_system_node
+     OpaqueSystem, VarSystem, CompoundSystem, \
+     partition_subsystems, ParamSystem, \
+     get_comm_if_active, collapse_to_system_node
 from openmdao.main.depgraph import _get_inner_connections, get_nondiff_groups, \
-                                   collapse_nodes, simple_node_iter, CollapsedGraph
+     collapse_nodes, simple_node_iter, CollapsedGraph
 from openmdao.main.exceptions import RunStopped
 from openmdao.main.interfaces import IVariableTree, IDriver
 from openmdao.main.depgraph import is_connection
@@ -160,7 +160,7 @@ class Workflow(object):
         """ Run the Components in this Workflow. """
         if not self._system.is_active():
             return
-            
+
         self._stop = False
         self._exec_count += 1
 
@@ -326,7 +326,7 @@ class Workflow(object):
         df vector."""
 
         self._system.calc_newton_direction(options=self.parent.gradient_options,
-                                          iterbase=self._iterbase())
+                                           iterbase=self._iterbase())
 
     def check_gradient(self, inputs=None, outputs=None, stream=sys.stdout, mode='auto'):
         """Compare the OpenMDAO-calculated gradient with one calculated
@@ -553,10 +553,10 @@ class Workflow(object):
                 if save_problem_formulation or \
                    self._check_path(path, includes, excludes):
                     self._rec_objectives.append(key)
-		    if key != objective.text:
-			outputs.append(name)
-		    else:
-			outputs.append(name + '.out0')
+                    if key != objective.text:
+                        outputs.append(name)
+                    else:
+                        outputs.append(name + '.out0')
 
         # Responses
         self._rec_responses = []
@@ -615,7 +615,7 @@ class Workflow(object):
                     outputs.append(output_name)
                     self._rec_outputs.append(output_name)
                     #self._rec_all_outputs.append(output_name)
-                    
+
         #####
         # also need get any outputs of comps that are not connected vars 
         #   and therefore not in the graph
@@ -625,7 +625,7 @@ class Workflow(object):
         #    
         #   also:
         #         scope._depgraph.list_outputs('comp2')
-        
+
         for comp in driver.workflow: 
             for output_name in scope._depgraph.list_outputs(comp.name):
                 if has_interface(comp, IDriver): # Only record outputs from drivers if they are framework variables
@@ -823,7 +823,7 @@ class Workflow(object):
         self._reduced_graph = None
         for comp in self:
             comp.pre_setup()
-    
+
     def setup_systems(self, system_type):
         """Get the subsystem for this workflow. Each
         subsystem contains a subgraph of this workflow's component
@@ -854,7 +854,7 @@ class Workflow(object):
         for node in params:
             param = node[0]
             reduced.node[param]['system'] = \
-                       ParamSystem(scope, reduced, param)
+                ParamSystem(scope, reduced, param)
 
         #outs = []
         #for p in parent_graph.predecessors(drvname):
@@ -872,7 +872,7 @@ class Workflow(object):
         cgraph = reduced.component_graph()
 
         opaque_map = {} # map of all internal comps to collapsed
-                              # name of opaque system
+                                # name of opaque system
         if self.scope._derivs_required:
             # collapse non-differentiable system groups into
             # opaque systems
@@ -946,7 +946,7 @@ class Workflow(object):
             self._system = cgraph.node[name].get('system')
         else:
             raise RuntimeError("setup_systems called on %s.workflow but component graph is empty!" %
-                                self.parent.get_pathname())
+                               self.parent.get_pathname())
 
     def get_req_cpus(self):
         """Return requested_cpus"""
@@ -983,7 +983,7 @@ def get_cycle_vars(graph, varmeta):
     # examine the graph to see if we have any cycles that we need to
     # deal with
     cycle_vars = []
-        
+
     # make a copy of the graph since we don't want to modify it
     g = graph.subgraph(graph.nodes_iter())
 

--- a/openmdao.main/src/openmdao/main/workflow.py
+++ b/openmdao.main/src/openmdao/main/workflow.py
@@ -16,11 +16,11 @@ from openmdao.main.mp_support import has_interface
 from openmdao.main.case import Case
 from openmdao.main.mpiwrap import MPI, MPI_info
 from openmdao.main.systems import SerialSystem, ParallelSystem, \
-     OpaqueSystem, VarSystem, CompoundSystem, \
-     partition_subsystems, ParamSystem, \
-     get_comm_if_active, collapse_to_system_node
+                                  OpaqueSystem, VarSystem, CompoundSystem, \
+                                  partition_subsystems, ParamSystem, \
+                                  get_comm_if_active, collapse_to_system_node
 from openmdao.main.depgraph import _get_inner_connections, get_nondiff_groups, \
-     collapse_nodes, simple_node_iter, CollapsedGraph
+                                   collapse_nodes, simple_node_iter, CollapsedGraph
 from openmdao.main.exceptions import RunStopped
 from openmdao.main.interfaces import IVariableTree, IDriver
 from openmdao.main.depgraph import is_connection


### PR DESCRIPTION
User can define a custom Jacobian for a constraint by giving the new 'jacs' attribute a function. This function should return a dictionary where the keys are the model parameters and the values are the Jacobian of the flattened constraint with respect to the flattened parameter.

Note: only supported in adjoint mode, and only supported by optimizers that request jacobians in a dict format (so, only pyOptSparse). Supported by all linear solvers. The custom jacobians are never used in finite difference.