### PR TITLE
Some fixes for array initialization and associated error reporting.

### DIFF
--- a/examples/openmdao.examples.metamodel_tutorial/openmdao/examples/metamodel_tutorial/test/test_metamodel_example.py
+++ b/examples/openmdao.examples.metamodel_tutorial/openmdao/examples/metamodel_tutorial/test/test_metamodel_example.py
@@ -12,10 +12,9 @@ class TestMetamodelTutorial(unittest.TestCase):
         pass
     
     def tearDown(self):
-        if os.path.exists('DOE_Trainer.csv'):
-            os.remove('DOE_Trainer.csv')
-        if os.path.exists('DOE_Validate.csv'):
-            os.remove('DOE_Validate.csv')
+        for name in ['DOE_Trainer.csv', 'DOE_Validate.csv']:
+            if os.path.exists(name):
+                os.remove(name)
             
     def test_krig_sin(self):
         sim = set_as_top(Simulation())

--- a/openmdao.main/src/openmdao/main/systems.py
+++ b/openmdao.main/src/openmdao/main/systems.py
@@ -1950,11 +1950,14 @@ class OpaqueSystem(SimpleSystem):
         inner_u = self._inner_system.vec['u']
         inner_du = self._inner_system.vec['du']
 
-        vnames = self._inner_system.list_inputs() + \
-                 self._inner_system.list_states()
-        inner_u.set_from_scope(self.scope, vnames)
+        # Make sure the inner_vector is initialized with values from the
+        # scope. Only need to do the inputs that span the outer and inner
+        # vectors.
+        bnames = self.list_inputs() + \
+                 self.list_states()        
+        inner_u.set_from_scope(self.scope, bnames)
         if self.complex_step is True:
-            inner_du.set_from_scope_complex(self.scope, vnames)
+            inner_du.set_from_scope_complex(self.scope, bnames)
 
         self._inner_system.run(iterbase, case_label=case_label, case_uuid=case_uuid)
 

--- a/openmdao.main/src/openmdao/main/test/test_system.py
+++ b/openmdao.main/src/openmdao/main/test/test_system.py
@@ -2,7 +2,7 @@
 import unittest
 
 import time
-from numpy import array, ones, eye
+import numpy as np
 
 from openmdao.main.api import Component, Driver, Assembly, set_as_top
 from openmdao.main.datatypes.api import Float, Array
@@ -135,10 +135,10 @@ class ABCDArrayComp(Component):
 
     def __init__(self, arr_size=9):
         super(ABCDArrayComp, self).__init__()
-        self.add_trait('a', Array(ones(arr_size, float), iotype='in'))
-        self.add_trait('b', Array(ones(arr_size, float), iotype='in'))
-        self.add_trait('c', Array(ones(arr_size, float), iotype='out'))
-        self.add_trait('d', Array(ones(arr_size, float), iotype='out'))
+        self.add_trait('a', Array(np.ones(arr_size, float), iotype='in'))
+        self.add_trait('b', Array(np.ones(arr_size, float), iotype='in'))
+        self.add_trait('c', Array(np.ones(arr_size, float), iotype='out'))
+        self.add_trait('d', Array(np.ones(arr_size, float), iotype='out'))
 
     def execute(self):
         time.sleep(self.delay)
@@ -161,8 +161,8 @@ class TestArrayComp(unittest.TestCase):
         top.connect('C2.c', 'C4.a')
         top.connect('C3.d', 'C4.b')
 
-        top.C1.a = ones(size, float) * 3.0
-        top.C1.b = ones(size, float) * 7.0
+        top.C1.a = np.ones(size, float) * 3.0
+        top.C1.b = np.ones(size, float) * 7.0
 
         try:
             top.run()
@@ -249,7 +249,7 @@ class UninitializedArray(unittest.TestCase):
         """
 
         top = set_as_top(Assembly())
-        top.add('out1', self.C4(eye(2)))
+        top.add('out1', self.C4(np.eye(2)))
         top.add('in1', self.C2())
         top.connect('out1.x', 'in1.x')
         top.driver.workflow.add(['out1', 'in1'])
@@ -271,7 +271,7 @@ class UninitializedArray(unittest.TestCase):
         """ 
         
         top = set_as_top(Assembly())
-        top.add('out1', self.C4(array(range(5))))
+        top.add('out1', self.C4(np.array(range(5))))
         top.add('in1', self.C2())
         top.add('in2', self.C2())
         top.connect('out1.x', 'in1.x')
@@ -306,6 +306,64 @@ class UninitializedArray(unittest.TestCase):
         else:
             self.fail("Should have raised error message: {}".format(expected))
 
+class Source(Component): 
+
+    s = Float(2, iotype="in")
+    out = Array(iotype="out")
+
+    def execute(self): 
+        self.out = self.s*np.ones(5)
+
+
+class Sink(Component): 
+
+    invar = Array(iotype="in")
+    out = Float(0, iotype="out")
+
+    def execute(self): 
+        self.out = np.sum(self.invar)
+
+
+class ArrayAsmb(Assembly): 
+
+    def configure(self): 
+        self.add('source', Source())
+        self.add('sink', Sink())
+
+        self.connect('source.out', 'sink.invar')
+
+        self.driver.workflow.add(['source','sink'])
+
+
+class TestArrayConnectErrors(unittest.TestCase): 
+
+    def test_wrong_initial_size(self): 
+        '''Give a clear error message if an array variable changes size at 
+        runtime compared to its initial value used to size the framework arrays''' 
+
+        t = set_as_top(ArrayAsmb())
+
+        t.source.out = np.zeros(2)
+        
+        try: 
+            t.run()
+        except RuntimeError as err:
+            self.assertEqual(str(err), 
+                             "Array size mis-match in 'source.out'. Initial shape was (2,) but found size (5,) at runtime")
+        else: 
+            self.fail('RuntimeError expected')
+
+    def test_unintialized_sink_array_var(self): 
+        '''Make sure you can run, even if the sink side of a connection is initialized''' 
+
+        t = set_as_top(ArrayAsmb())
+        t.add('driver', SimpleDriver())
+        t.driver.add_parameter('source.s', low=-10, high=10)
+        t.driver.add_constraint('sink.out < 10')
+
+        t.source.out = np.zeros((5,))
+        
+        t.run() # should run without error
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao.main/src/openmdao/main/vecwrapper.py
+++ b/openmdao.main/src/openmdao/main/vecwrapper.py
@@ -80,8 +80,14 @@ class VecWrapperBase(object):
             try:
                 view[idxs] = value.flat
             except Exception as err:
-                raise RuntimeError("cannot set array %s to value:\n %s\n %s" %
-                                    (name, str(value), str(err)))
+                if value.shape != view[idxs].shape:
+                    msg = "Array size mis-match in '%s'. " % name[0]
+                    msg += "Initial shape was %s " % str(view[idxs].shape)
+                    msg += "but found size %s at runtime" % str(value.shape)
+                else:
+                    msg = "cannot set array %s to value:\n %s\n %s" % \
+                                    (name, str(value), str(err))
+                raise RuntimeError(msg)
         else:
             view[idxs] = value
 


### PR DESCRIPTION
1. Source -> target propagation added to the setup so that all flattenable array variables have an array of the right shape before run time.
2. Fixed up the error message that is printed when a comp tries to change the shape of one of its output arrays.
3. Fixed Opaquesystem's run method so that it only loads the inner_system vector at the boundary inputs before running, instead of all of the input (target) edge sides.