### PR TITLE
KSP fix and cleanup

### DIFF
--- a/contrib/testmpi/test_linear_solver_KSP.py
+++ b/contrib/testmpi/test_linear_solver_KSP.py
@@ -16,6 +16,7 @@ from openmdao.main.datatypes.api import Float, Array
 from openmdao.main.mpiwrap import PETSc
 from openmdao.main.test.simpledriver import SimpleDriver
 from openmdao.main.test.test_derivatives import ArrayComp2D
+from openmdao.test.execcomp import ExecCompWithDerivatives, ExecComp
 from openmdao.util.testutil import assert_rel_error
 
 
@@ -174,9 +175,9 @@ class Testcase_PetSc_KSP(unittest.TestCase):
         assert_rel_error(self, J[1, 0], 0.0969276, 0.0001)
 
     def test_custom_jacobian(self):
-        
+
         class AComp(Component):
-            
+
             x = Array([[1.0, 3.0], [-2.0, 4.0]], iotype='in')
             y = Array(np.zeros((2, 2)), iotype='out')
 
@@ -186,12 +187,12 @@ class Testcase_PetSc_KSP(unittest.TestCase):
                                    [4.0, 2.0, -1.1, 3.4],
                                    [7.7, 6.6, 4.4, 1.1],
                                    [0.1, 3.3, 6.8, -5.5]])
-            
+
             def execute(self):
                 """ Run arraycomp"""
                 y = self.J.dot(self.x.flatten())
                 self.y = y.reshape((2,2))
-                
+
             def list_deriv_vars(self):
                 """ x and y """
                 input_keys = ('x',)
@@ -201,7 +202,7 @@ class Testcase_PetSc_KSP(unittest.TestCase):
             def provideJ(self):
                 """Analytical first derivatives"""
                 return self.J
-            
+
         def fake_jac():
             """ Returns a User-defined Jacobian. The values are
             totally wrong to facilitate testing. """
@@ -210,24 +211,24 @@ class Testcase_PetSc_KSP(unittest.TestCase):
                                        [104, 105, 106, 107],
                                        [108, 109, 110, 111],
                                        [112, 113, 114, 115]])
-            
+
             return jacs
-        
+
         top = set_as_top(Assembly())
         top.add('driver', SimpleDriver())
         top.add('comp', AComp())
         top.driver.workflow.add('comp')
         top.driver.add_parameter('comp.x', low=10, high=10)
         top.driver.add_constraint('comp.y < 1', jacs=fake_jac)
-        
+
         # petsc KSP, inequality constraints
         top.run()
-        
+
         J = top.driver.calc_gradient(mode='forward', return_format='dict')
         J = J['_pseudo_0.out0']['comp.x']
         diff = np.abs(J - top.comp.J)
         assert_rel_error(self, diff.max(), 0.0, 1e-4)
-        
+
         J = top.driver.calc_gradient(mode='adjoint', return_format='dict')
         J = J['_pseudo_0.out0']['comp.x']
         diff = np.abs(J - fake_jac()['comp.x'])
@@ -334,6 +335,201 @@ class Testcase_PetSc_KSP(unittest.TestCase):
                                      outputs=['nest.y[1][:]'],
                                      mode='fd')
         diff = J - Jsub
+
+    def test_nested_2Darray_simul_element_and_full_connection(self):
+
+        top = Assembly()
+        top.add('comp', ArrayComp2D())
+        top.add('nest', Assembly())
+        top.nest.add('comp', ArrayComp2D())
+        top.driver.gradient_options.lin_solver = 'petsc_ksp'
+        top.nest.driver.gradient_options.lin_solver = 'petsc_ksp'
+
+        top.nest.driver.workflow.add(['comp'])
+        top.nest.create_passthrough('comp.x')
+        top.nest.create_passthrough('comp.y')
+
+        top.add('driver', SimpleDriver())
+        top.driver.workflow.add(['nest', 'comp'])
+        top.connect('nest.y', 'comp.x')
+        top.driver.add_parameter('nest.x[0][0]', low=-10, high=10)
+        top.driver.add_objective('comp.y[0][0]')
+        top.driver.add_constraint('nest.y[0][1] < 0')
+        top.run()
+
+        J = top.driver.calc_gradient(mode='forward')
+        assert_rel_error(self, J[0, 0], 24.0, .000001)
+        assert_rel_error(self, J[1, 0], 4.0, .000001)
+
+        J = top.driver.calc_gradient(mode='adjoint')
+        assert_rel_error(self, J[0, 0], 24.0, .000001)
+        assert_rel_error(self, J[1, 0], 4.0, .000001)
+
+        J = top.driver.calc_gradient(mode='fd')
+        assert_rel_error(self, J[0, 0], 24.0, .000001)
+        assert_rel_error(self, J[1, 0], 4.0, .000001)
+
+    def test_nested_2Darray_simul_element_and_full_connection2(self):
+        # Slightly different config
+
+        top = Assembly()
+        top.add('nest', Assembly())
+        top.nest.add('comp1', ArrayComp2D())
+        top.nest.add('comp2', ArrayComp2D())
+        top.driver.gradient_options.lin_solver = 'petsc_ksp'
+        top.nest.driver.gradient_options.lin_solver = 'petsc_ksp'
+
+        top.nest.driver.workflow.add(['comp1', 'comp2'])
+        top.nest.connect('comp1.y', 'comp2.x')
+        top.nest.create_passthrough('comp1.x')
+        top.nest.create_passthrough('comp1.y')
+        top.nest.add('yy', Array(iotype='out'))
+        top.nest.connect('comp2.y', 'yy')
+
+        top.add('driver', SimpleDriver())
+        top.driver.workflow.add(['nest'])
+        top.driver.add_parameter('nest.x[0][0]', low=-10, high=10)
+        top.driver.add_objective('nest.yy[0][0]')
+        top.driver.add_constraint('nest.y[0][1] < 0')
+        top.run()
+
+        J = top.driver.workflow.calc_gradient(mode='forward')
+        assert_rel_error(self, J[0, 0], 24.0, .000001)
+        assert_rel_error(self, J[1, 0], 4.0, .000001)
+
+        J = top.driver.workflow.calc_gradient(mode='adjoint')
+        assert_rel_error(self, J[0, 0], 24.0, .000001)
+        assert_rel_error(self, J[1, 0], 4.0, .000001)
+
+        J = top.driver.workflow.calc_gradient(mode='fd')
+        assert_rel_error(self, J[0, 0], 24.0, .000001)
+        assert_rel_error(self, J[1, 0], 4.0, .000001)
+
+    def test_nested_array_full_and_partial_passthrough(self):
+
+        top = Assembly()
+        top.add('nest', Assembly())
+        top.nest.add('comp1', ArrayComp2D())
+        top.nest.add('comp2', ArrayComp2D())
+        top.driver.gradient_options.lin_solver = 'petsc_ksp'
+        top.nest.driver.gradient_options.lin_solver = 'petsc_ksp'
+
+        top.nest.driver.workflow.add(['comp1', 'comp2'])
+        top.nest.create_passthrough('comp1.x', 'x')
+        top.nest.create_passthrough('comp1.y', 'y1')
+        top.nest.create_passthrough('comp2.y', 'y2')
+        top.nest.connect('x[-1, -1]', 'comp2.x[-1, -1]')
+
+        top.add('driver', SimpleDriver())
+        top.driver.workflow.add(['nest'])
+        top.run()
+
+        Jbase = top.nest.comp1.provideJ()
+
+        J = top.driver.calc_gradient(inputs=['nest.x'],
+                                     outputs=['nest.y1', 'nest.y2'],
+                                     mode='fd')
+        diff = abs(J[0:4, :] - Jbase)
+        assert_rel_error(self, diff.max(), 0.0, .00001)
+        diff = abs(J[0:4, -1] - Jbase[:, -1])
+        assert_rel_error(self, diff.max(), 0.0, .00001)
+        diff = abs(J[4:, :-1])
+        assert_rel_error(self, diff.max(), 0.0, .00001)
+
+        J = top.driver.calc_gradient(inputs=['nest.x'],
+                                     outputs=['nest.y1', 'nest.y2'],
+                                     mode='forward')
+        diff = abs(J[0:4, :] - Jbase)
+        assert_rel_error(self, diff.max(), 0.0, .00001)
+        diff = abs(J[0:4, -1] - Jbase[:, -1])
+        assert_rel_error(self, diff.max(), 0.0, .00001)
+        diff = abs(J[4:, :-1])
+        assert_rel_error(self, diff.max(), 0.0, .00001)
+
+        Jdict = top.driver.calc_gradient(inputs=['nest.x'],
+                                         outputs=['nest.y1', 'nest.y2'],
+                                         mode='forward',
+                                         return_format='dict')
+        diff = Jdict['nest.y1']['nest.x'] - Jbase
+        assert_rel_error(self, diff.max(), 0.0, .00001)
+
+        diff = Jdict['nest.y2']['nest.x'] - J[4:, :]
+        assert_rel_error(self, diff.max(), 0.0, .00001)
+
+        J = top.driver.calc_gradient(inputs=['nest.x'],
+                                     outputs=['nest.y1', 'nest.y2'],
+                                     mode='adjoint')
+        diff = abs(J[0:4, :] - Jbase)
+        assert_rel_error(self, diff.max(), 0.0, .00001)
+        diff = abs(J[0:4, -1] - Jbase[:, -1])
+        assert_rel_error(self, diff.max(), 0.0, .00001)
+        diff = abs(J[4:, :-1])
+        assert_rel_error(self, diff.max(), 0.0, .00001)
+
+        Jdict = top.driver.calc_gradient(inputs=['nest.x'],
+                                         outputs=['nest.y1', 'nest.y2'],
+                                         mode='adjoint',
+                                         return_format='dict')
+        diff = Jdict['nest.y1']['nest.x'] - Jbase
+        assert_rel_error(self, diff.max(), 0.0, .00001)
+
+        diff = Jdict['nest.y2']['nest.x'] - J[4:, :]
+        assert_rel_error(self, diff.max(), 0.0, .00001)
+
+    def test_input_as_output(self):
+
+        top = set_as_top(Assembly())
+        top.add('comp1', ExecCompWithDerivatives(['y=2.0*x + 3.0*x2'],
+                                                 ['dy_dx = 2.0', 'dy_dx2 = 3.0']))
+        top.add('comp2', ExecCompWithDerivatives(['y=3.0*x'],
+                                                 ['dy_dx = 3.0']))
+        top.connect('comp1.y', 'comp2.x')
+        top.add('driver', SimpleDriver())
+        top.driver.workflow.add(['comp1', 'comp2'])
+        #top.driver.add_parameter('comp1.x', low=-100, high=100)
+        top.driver.add_objective('comp1.y + comp2.y + 5*comp1.x')
+        top.driver.gradient_options.lin_solver = 'petsc_ksp'
+
+        objs = top.driver.get_objectives().values()
+        obj = '%s.out0' % objs[0].pcomp_name
+
+        top.comp1.x = 1.0
+        top.run()
+
+        J = top.driver.calc_gradient(inputs=['comp1.x'],
+                                     outputs=[obj], mode='forward')
+
+        assert_rel_error(self, J[0, 0], 13.0, 0.0001)
+
+        J = top.driver.calc_gradient(inputs=['comp1.x'],
+                                              outputs=[obj], mode='fd')
+        assert_rel_error(self, J[0, 0], 13.0, 0.0001)
+
+        top.driver.run()
+
+        J = top.driver.calc_gradient(inputs=['comp1.x'],
+                                     outputs=[obj], mode='adjoint')
+        assert_rel_error(self, J[0, 0], 13.0, 0.0001)
+
+        J = top.driver.calc_gradient(inputs=['comp1.x', 'comp1.x2'],
+                                     outputs=[obj], mode='forward')
+        assert_rel_error(self, J[0, 0], 13.0, 0.0001)
+        assert_rel_error(self, J[0, 1], 12.0, 0.0001)
+
+        J = top.driver.calc_gradient(inputs=['comp1.x', 'comp1.x2'],
+                                     outputs=[obj], mode='adjoint')
+        assert_rel_error(self, J[0, 0], 13.0, 0.0001)
+        assert_rel_error(self, J[0, 1], 12.0, 0.0001)
+
+        J = top.driver.calc_gradient(inputs=[('comp1.x',), ('comp1.x2',)],
+                                     outputs=[obj], mode='forward')
+        assert_rel_error(self, J[0, 0], 13.0, 0.0001)
+        assert_rel_error(self, J[0, 1], 12.0, 0.0001)
+
+        J = top.driver.calc_gradient(inputs=[('comp1.x',), ('comp1.x2',)],
+                                     outputs=[obj], mode='adjoint')
+        assert_rel_error(self, J[0, 0], 13.0, 0.0001)
+        assert_rel_error(self, J[0, 1], 12.0, 0.0001)
 
 
 

--- a/openmdao.main/src/openmdao/main/array_helpers.py
+++ b/openmdao.main/src/openmdao/main/array_helpers.py
@@ -119,9 +119,9 @@ def to_slice(idxs):
         else:
             imin = min(idxs)
             imax = max(idxs)
-            
+
         stride = idxs[1]-idxs[0]
-        
+
         if stride == 0:
             return idxs
 
@@ -210,11 +210,6 @@ def get_flattened_index(index, shape, cvt_to_slice=True):
         indices = zip(*itertools.product(*indices))
 
     idxs = ravel_multi_index(indices, dims=shape)
-    # if len(idxs) == 1:
-    #     # _flat_idx_cache[(sindex, shape)] = slice(idxs[0], idxs[0]+1)
-    #     # return slice(idxs[0], idxs[0]+1)
-    #     _flat_idx_cache[(sindex, shape, cvt_to_slice)] = idxs[0]
-    #     return idxs[0]
 
     # see if we can convert the discrete list of indices
     # into a single slice object

--- a/openmdao.main/src/openmdao/main/systems.py
+++ b/openmdao.main/src/openmdao/main/systems.py
@@ -875,7 +875,7 @@ class System(object):
             base = vname[0].split('[',1)[0]
             base = self.scope.name2collapsed[base]
             ivar = varkeys.index(base)
-            ind += self.scope._var_meta[vname]['flat_idx']
+            ind = self.scope._var_meta[vname]['flat_idx'][ind]
 
         if self.local_var_sizes[self.mpi.rank, ivar] > 0:
             ind += numpy.sum(self.local_var_sizes[:, :ivar])

--- a/openmdao.main/src/openmdao/main/systems.py
+++ b/openmdao.main/src/openmdao/main/systems.py
@@ -868,7 +868,7 @@ class System(object):
         self.sol_vec.array[:] = 0.0
         self.vec['dp'].array[:] = 0.0
 
-        varkeys = self.flat_vars.keys()
+        varkeys = self.vector_vars.keys()
         if vname in varkeys:
             ivar = varkeys.index(vname)
         else:

--- a/openmdao.main/src/openmdao/main/test/test_egg_save.py
+++ b/openmdao.main/src/openmdao/main/test/test_egg_save.py
@@ -299,7 +299,7 @@ class TestCase(unittest.TestCase):
         self.tempdir = tempfile.mkdtemp(prefix='test_eggsave-')
         os.chdir(self.tempdir)
         SimulationRoot.chroot(self.tempdir)
-        
+
         self.model = set_as_top(Model())
         self.model.name = 'Egg_TestModel'
         self.child_objs = [self.model.Source, self.model.Sink,
@@ -318,16 +318,16 @@ class TestCase(unittest.TestCase):
                 shutil.rmtree(self.tempdir)
             except OSError:
                 pass
-        
+
         # Not always added, but we need to ensure the egg is not in sys.path.
         egg_name = self.egg_name
         paths = sys.path
-        
+
         if egg_name is not None:
             if sys.platform == "win32":
                 egg_name = egg_name.lower()
                 paths = [path.lower() for path in sys.path]
-                
+
             for i, path in enumerate(paths):
                 if path.endswith(egg_name) or egg_name in path:
                     del sys.path[i]
@@ -445,7 +445,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(self.model.Sink.binary_file.binary, True)
 
         self.assertEqual(self.model.Sink.executions, 3)
-        
+
 
         # Restore in test directory.
         orig_dir = os.getcwd()
@@ -997,7 +997,15 @@ comp.run()
 
     def create_and_check_model(self, factory, name, file_data):
         """ Create a complete model instance and check it's operation. """
-        model = factory.create('Egg_TestModel', name=name)
+
+        # Suppress a warning that has cropped up in these tests. The warning
+        # complains that our temp directory is an unsafe location for an
+        # extraction path.
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            model = factory.create('Egg_TestModel', name=name)
+
         logging.debug('model.directory = %s' % model.directory)
         if model is None:
             self.fail("Create of '%s' failed." % name)

--- a/openmdao.main/src/openmdao/main/test/test_implicit_component.py
+++ b/openmdao.main/src/openmdao/main/test/test_implicit_component.py
@@ -24,7 +24,7 @@ class ImplicitWithSolver(ImplicitComponent):
         You can override this function to provide your own internal solve."""
         #print "start solve", self.name
         x0 = self.get_state()
-        fsolve(self._solve_callback, x0, xtol=1e-12)
+        fsolve(self._solve_callback, x0, xtol=1e-8)
         #print "end solve", self.name
 
     def _solve_callback(self, X):
@@ -516,6 +516,7 @@ class Testcase_implicit(unittest.TestCase):
         model.driver.add_constraint('comp1.z = comp2.z')
         model.driver.add_constraint('comp2.x = comp1.x')
         model.driver.add_constraint('comp2.y = comp1.y')
+        model.driver.tol
 
         model.run()
 

--- a/openmdao.main/src/openmdao/main/test/test_system.py
+++ b/openmdao.main/src/openmdao/main/test/test_system.py
@@ -123,7 +123,7 @@ class TestcaseParaboloid(unittest.TestCase):
         top.comp.y = 5
 
         top.run()
-        
+
         sys = top._system.find_system('comp')
         self.assertTrue(sys.name == 'comp')
         sys = top._system.find_system("('_pseudo_0', 'comp', 'comp.x', 'comp.y')")
@@ -237,9 +237,9 @@ class UninitializedArray(unittest.TestCase):
         top.add('in1', self.C2())
         top.connect('out1.x', 'in1.x')
         top.driver.workflow.add(['out1', 'in1'])
-        
+
         top.run()
-       
+
         """
         out1.x is:
             - initialized
@@ -253,7 +253,7 @@ class UninitializedArray(unittest.TestCase):
         top.add('in1', self.C2())
         top.connect('out1.x', 'in1.x')
         top.driver.workflow.add(['out1', 'in1'])
-        
+
         top.run()
 
         """
@@ -268,8 +268,8 @@ class UninitializedArray(unittest.TestCase):
             - flattenable
             - the source of a connection
             - a slice
-        """ 
-        
+        """
+
         top = set_as_top(Assembly())
         top.add('out1', self.C4(np.array(range(5))))
         top.add('in1', self.C2())
@@ -277,9 +277,9 @@ class UninitializedArray(unittest.TestCase):
         top.connect('out1.x', 'in1.x')
         top.connect('in1.x[::1]', 'in2.x')
         top.driver.workflow.add(['out1', 'in1', 'in2'])
-        
+
         top.run()
-       
+
         """
         sub.out1.x is:
             - not initialized
@@ -288,7 +288,7 @@ class UninitializedArray(unittest.TestCase):
             - not a slice
         """
         expected = "sub: out1.x was not initialized. OpenMDAO does not support uninitialized variables."
- 
+
         top = set_as_top(Assembly())
         top.add('sub', Assembly())
         top.sub.add('out1', self.C1())
@@ -306,27 +306,27 @@ class UninitializedArray(unittest.TestCase):
         else:
             self.fail("Should have raised error message: {}".format(expected))
 
-class Source(Component): 
+class Source(Component):
 
     s = Float(2, iotype="in")
     out = Array(iotype="out")
 
-    def execute(self): 
+    def execute(self):
         self.out = self.s*np.ones(5)
 
 
-class Sink(Component): 
+class Sink(Component):
 
     invar = Array(iotype="in")
     out = Float(0, iotype="out")
 
-    def execute(self): 
+    def execute(self):
         self.out = np.sum(self.invar)
 
 
-class ArrayAsmb(Assembly): 
+class ArrayAsmb(Assembly):
 
-    def configure(self): 
+    def configure(self):
         self.add('source', Source())
         self.add('sink', Sink())
 
@@ -335,34 +335,33 @@ class ArrayAsmb(Assembly):
         self.driver.workflow.add(['source','sink'])
 
 
-class TestArrayConnectErrors(unittest.TestCase): 
+class TestArrayConnectErrors(unittest.TestCase):
 
-    def test_wrong_initial_size(self): 
-        '''Give a clear error message if an array variable changes size at 
-        runtime compared to its initial value used to size the framework arrays''' 
+    def test_wrong_initial_size(self):
+        # Give a clear error message if an array variable changes size at
+        # runtime compared to its initial value used to size the framework arrays
 
         t = set_as_top(ArrayAsmb())
 
         t.source.out = np.zeros(2)
-        
-        try: 
+
+        try:
             t.run()
         except RuntimeError as err:
-            self.assertEqual(str(err), 
+            self.assertEqual(str(err),
                              "Array size mis-match in 'source.out'. Initial shape was (2,) but found size (5,) at runtime")
-        else: 
+        else:
             self.fail('RuntimeError expected')
 
-    def test_unintialized_sink_array_var(self): 
-        '''Make sure you can run, even if the sink side of a connection is initialized''' 
-
+    def test_unintialized_sink_array_var(self):
+        # Make sure you can run, even if the sink side of a connection is initialized
         t = set_as_top(ArrayAsmb())
         t.add('driver', SimpleDriver())
         t.driver.add_parameter('source.s', low=-10, high=10)
         t.driver.add_constraint('sink.out < 10')
 
         t.source.out = np.zeros((5,))
-        
+
         t.run() # should run without error
 
 if __name__ == "__main__":

--- a/openmdao.util/src/openmdao/util/eggwriter.py
+++ b/openmdao.util/src/openmdao/util/eggwriter.py
@@ -118,9 +118,12 @@ def write(name, version, doc, entry_map, src_files, distributions, modules,
         for path in filenames:
             if path.endswith('.py'):
                 path = os.path.join(dirpath[2:], path)  # Skip leading './'
-                files.append(path)
-                size += os.path.getsize(path)
-                sources.append(path)
+
+                # No reason for a file to appear twice in our file list.
+                if path not in files:
+                    files.append(path)
+                    size += os.path.getsize(path)
+                    sources.append(path)
 
     # Package info -> EGG-INFO/PKG-INFO
     pkg_info = []


### PR DESCRIPTION
1. FIx in the system._compute_derivatives function which is used by the KSP solver, so that it finds the correct index for gradients of array slices across assemblies when the full array is connected to the boundary.
2. KSP tests expanded to includes some more tricky cases.
3. Fixed a couple of tests to get rid of warnings.
4. Fixed eggwriter.py so that it doesn't write the same file twice.