### PR TITLE
Small behavior change for custom constraint jacobians

### DIFF
--- a/openmdao.main/src/openmdao/main/linearsolver.py
+++ b/openmdao.main/src/openmdao/main/linearsolver.py
@@ -91,7 +91,7 @@ class LinearSolver(object):
             if param in jacs:
                 J[con][param] = jacs[param]
                 
-            # Assume zero if user did not explicitly defined.
+            # Assume zero if user did not explicitly define.
             else:
                 psize = self._system.get_size(param)
                 csize = self._system.get_size(con)

--- a/openmdao.main/src/openmdao/main/linearsolver.py
+++ b/openmdao.main/src/openmdao/main/linearsolver.py
@@ -87,7 +87,15 @@ class LinearSolver(object):
 
         jacs = self.custom_jacs[con]()
         for param in params:
-            J[con][param] = jacs[param]
+            
+            if param in jacs:
+                J[con][param] = jacs[param]
+                
+            # Assume zero if user did not explicitly defined.
+            else:
+                psize = self._system.get_size(param)
+                csize = self._system.get_size(con)
+                J[con][param] = np.zeros((csize, psize))
 
 
 class ScipyGMRES(LinearSolver):

--- a/openmdao.main/src/openmdao/main/test/test_hasconstraints.py
+++ b/openmdao.main/src/openmdao/main/test/test_hasconstraints.py
@@ -566,6 +566,36 @@ class HasConstraintsTestCase(unittest.TestCase):
         diff = np.abs(J - fake_jac()['comp.x'])
         assert_rel_error(self, diff.max(), 0.0, 1e-4)
 
+        # Test behavoir
+
+        def fake_jac2():
+            """ Returns a User-defined Jacobian. The values are
+            totally wrong to facilitate testing. """
+            jacs = {}
+            jacs['Junk'] = np.array([[100.0, 101, 102, 103],
+                                     [104, 105, 106, 107],
+                                     [108, 109, 110, 111],
+                                     [112, 113, 114, 115]])
+    
+            return jacs
+
+        top.driver.clear_constraints()
+        top._pseudo_count = 0
+        top.driver.add_constraint('comp.y = 1', jacs=fake_jac2)
+        top._setup()
+        top.run()
+    
+        J = top.driver.calc_gradient(mode='forward', return_format='dict')
+        J = J['_pseudo_0.out0']['comp.x']
+        diff = np.abs(J - top.comp.J)
+        assert_rel_error(self, diff.max(), 0.0, 1e-4)
+    
+        J = top.driver.calc_gradient(mode='adjoint', return_format='dict')
+        J = J['_pseudo_0.out0']['comp.x']
+        J_abs = np.abs(J)
+        assert_rel_error(self, J_abs.max(), 0.0, 1e-4)
+
+
 
 class Has2SidedConstraintsTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Implemented "big boy rules", so user can leave choose to leave constraint derivs with respect to some parameters undefined and they will be assumed zero.