### PR TITLE
Fix installer from 'python' to sys.executable.

### DIFF
--- a/install_openmdao_dev.py
+++ b/install_openmdao_dev.py
@@ -33,7 +33,8 @@ def check_dist():
     return dist
 
 def install(dist):
-    cmd =['python']
+    #call the appropriate installer with the python that ran this script.
+    cmd = [sys.executable]
     if dist == "Anaconda":
         cmd.append('openmdao.devtools/src/openmdao/devtools/conda_build.py')
         cmd.append('dev')


### PR DESCRIPTION
A more robust way to do the install.  Rather than front-of-path python, use the one that called the script.  Duh.  Never crossed our minds during the first iteration.