### PR TITLE
Fix for a problem when passing a noflat slice

### DIFF
--- a/openmdao.main/src/openmdao/main/vecwrapper.py
+++ b/openmdao.main/src/openmdao/main/vecwrapper.py
@@ -467,7 +467,7 @@ class DataTransfer(object):
                  scatter_conns, noflat_vars):
         self.scatter = None
         self.scatter_conns = scatter_conns
-        self.noflat_vars = list(noflat_vars)
+        self.noflat_vars = sorted(noflat_vars)
 
         if not (MPI or scatter_conns or noflat_vars):
             return  # no data to xfer


### PR DESCRIPTION
The list of noflat vars in the DataTransfer object needed to be sorted so that the full array is always set to scope before any slices. Otherwise, the size of the array in the target cannot be correctly set.